### PR TITLE
start nginx before certbot and kill using pkill since service command fails

### DIFF
--- a/nginx-certbot/startup.sh
+++ b/nginx-certbot/startup.sh
@@ -18,6 +18,6 @@ if [ "$TEST_CERT" = 'true' ] ; then
 fi
 service nginx start
 $cmd
-pkill -9 nginx
+service nginx stop
 nginx -g 'daemon off;'
 

--- a/nginx-certbot/startup.sh
+++ b/nginx-certbot/startup.sh
@@ -16,7 +16,8 @@ fi
 if [ "$TEST_CERT" = 'true' ] ; then
   cmd=$cmd" --test-cert"
 fi
+service nginx start
 $cmd
-service nginx stop
+pkill -9 nginx
 nginx -g 'daemon off;'
 


### PR DESCRIPTION
certbot command fails for some nodes when it's deployed from the marketplace due to timeout error. It works when I start nginx manually but `service nginx stop` after certbot command fails. So I replaced it with `pkill -9 nginx`.

New flist: https://hub.grid.tf/omar0.3bot/omarelawady-nginx-certbot-prestart.flist

Tested on cryptpad, gitea.