### PR TITLE
Retry six times in case of certificate failure

### DIFF
--- a/nginx-certbot/startup.sh
+++ b/nginx-certbot/startup.sh
@@ -17,7 +17,14 @@ if [ "$TEST_CERT" = 'true' ] ; then
   cmd=$cmd" --test-cert"
 fi
 service nginx start
-$cmd
+
+for i in {1..6}; do
+if $cmd ; then
+        break
+fi
+sleep 10
+done
+
 service nginx stop
 nginx -g 'daemon off;'
 


### PR DESCRIPTION
Due to network lags the certificate generation fails with this exception in letsencrypt log.

```
2020-09-20 12:02:22,762:DEBUG:certbot.error_handler:Calling registered functions
2020-09-20 12:02:22,763:INFO:certbot.auth_handler:Cleaning up challenges
2020-09-20 12:02:23,905:DEBUG:certbot.log:Exiting abnormally:
Traceback (most recent call last):
  File "/usr/bin/certbot", line 11, in <module>
    load_entry_point('certbot==0.31.0', 'console_scripts', 'certbot')()
  File "/usr/lib/python3/dist-packages/certbot/main.py", line 1365, in main
    return config.func(config, plugins)
  File "/usr/lib/python3/dist-packages/certbot/main.py", line 1119, in run
    certname, lineage)
  File "/usr/lib/python3/dist-packages/certbot/main.py", line 121, in _get_and_save_cert
    lineage = le_client.obtain_and_enroll_certificate(domains, certname)
  File "/usr/lib/python3/dist-packages/certbot/client.py", line 410, in obtain_and_enroll_certificate
    cert, chain, key, _ = self.obtain_certificate(domains)
  File "/usr/lib/python3/dist-packages/certbot/client.py", line 353, in obtain_certificate
    orderr = self._get_order_and_authorizations(csr.data, self.config.allow_subset_of_names)
  File "/usr/lib/python3/dist-packages/certbot/client.py", line 389, in _get_order_and_authorizations
    authzr = self.auth_handler.handle_authorizations(orderr, best_effort)
  File "/usr/lib/python3/dist-packages/certbot/auth_handler.py", line 82, in handle_authorizations
    self._respond(aauthzrs, resp, best_effort)
  File "/usr/lib/python3/dist-packages/certbot/auth_handler.py", line 168, in _respond
    self._poll_challenges(aauthzrs, chall_update, best_effort)
  File "/usr/lib/python3/dist-packages/certbot/auth_handler.py", line 239, in _poll_challenges
    raise errors.FailedChallenges(all_failed_achalls)
certbot.errors.FailedChallenges: Failed authorization procedure. omar0-peertube-test12b.tfgw-testnet-01.ava.tf (http-01): urn:ietf:params:acme:error:serverInternal :: The server experienced an internal error :: During secondary validation: Fetching http://omar0-peertube-test12b.tfgw-testnet-01.ava.tf/.well-known/acme-challenge/RE1qycJ0Fk1zMa74KW9H1x4T81XQn7rvhWcus3DAXsU: Timeout after connect (your server may be slow or overloaded)
```