### PR TITLE
Adding grid3 taiga image

### DIFF
--- a/grid3_taiga/Dockerfile
+++ b/grid3_taiga/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" |  tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive TZ=Europe/Belgium apt-get install -y docker-ce docker-ce-cli containerd.io openssh-server ufw && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
+COPY ./zinit /sbin/zinit
+COPY ./scripts/ /scripts/
+COPY ./zinit_services/ /etc/zinit/
+COPY ./docker /docker/
+RUN chmod +x /sbin/zinit && chmod +x /scripts/*.sh
+
+ENTRYPOINT ["/sbin/zinit", "init"]

--- a/grid3_taiga/README.md
+++ b/grid3_taiga/README.md
@@ -1,0 +1,59 @@
+# grid3_taiga
+
+get Taiga up and running in on grid3 VM
+
+## what in this image
+- [Taiga](https://www.taiga.io/) on Ubuntu 20.04
+- include preinstalled openssh-client, openssh-server, curl, docker and docker-compose.
+- ufw with restricted rules applied.
+- zinit process manager
+
+## Building
+
+in the grid3_ubuntu20.04_debug directory
+
+`docker build -t {user|org}/grid3_taiga_docker:latest .`
+
+## Deploying on grid 3
+
+### convert the docker image to Zero-OS flist
+Easiest way to convert the docker image to Flist is using [Docker Hub Converter tool](https://hub.grid.tf/docker-convert), make sure you already built and pushed the docker image to docker hub before using this tool.
+
+### Deploying
+Easiest way to deploy a VM using the flist is to head to to our [playground](https://play.grid.tf) and deploy a Virtual Machine by providing this flist URL.
+make sure to provide the correct entrypoint.
+
+another way you could use is using our terraform plugin [docs](https://github.com/threefoldtech/terraform-provider-grid)
+
+here you can find a full terraform file example to deploy this flist on grid3 [link](https://github.com/threefoldtech/terraform-provider-grid/tree/development/examples/resources) 
+
+## Flist
+### URL:
+TODO: should be updated to official repo.
+```
+https://hub.grid.tf/samehabouelsaad.3bot/abouelsaad-grid3_taiga_docker-latest.flist
+```
+
+### Entrypoint
+- `/sbin/zinit init`
+
+
+### Required Env Vars
+- `SSH_KEY`: User SSH public key.
+- `DOMAIN_NAME`: the domain name, eg: grid3taiga.gent01.dev.grid.tf
+
+### Optional Env Vars (but some functionality won't be available if these env vars doesn't set)
+
+#### superuser account (Admin)
+- `ADMIN_USERNAME`: user name to access the admin dashboard on `{doamin name}/admin/`.
+- `ADMIN_PASSWORD`: the admin password for admin dashboard.
+- `ADMIN_EMAIL`: email address for admin user.
+
+#### smtp server settings
+- `DEFAULT_FROM_EMAIL`: the from email shown when sent emails to taiga members.
+- `EMAIL_USE_TLS`: either "True" or "False".
+- `EMAIL_USE_SSL`: either "True" or "False".
+- `EMAIL_HOST`: eg, "smtp.gmail.com".
+- `EMAIL_PORT`: smtp server port.
+- `EMAIL_HOST_USER`: the account address to sent the emails from.
+- `EMAIL_HOST_PASSWORD`: the account password.

--- a/grid3_taiga/README.md
+++ b/grid3_taiga/README.md
@@ -10,7 +10,7 @@ get Taiga up and running in on grid3 VM
 
 ## Building
 
-in the grid3_ubuntu20.04_debug directory
+in the grid3_taiga directory
 
 `docker build -t {user|org}/grid3_taiga_docker:latest .`
 

--- a/grid3_taiga/README.md
+++ b/grid3_taiga/README.md
@@ -6,7 +6,15 @@ get Taiga up and running in on grid3 VM
 - [Taiga](https://www.taiga.io/) on Ubuntu 20.04
 - include preinstalled openssh-client, openssh-server, curl, docker and docker-compose.
 - ufw with restricted rules applied.
-- zinit process manager
+- zinit process manager which is configured with these services:
+     - sshd: starting OpenSSH server daemon 
+     - contained: starting containerd daemon, which manages the complete docker containers lifecycle.
+     - dockerd: starting the Docker daemon.
+     - taiga: Define different taiga services/containers, and spin everything up. 
+     - sshd-init: Add the user SSH key to authorized_keys, so he can log in remotely to the host which running this image.
+     - ufw-init: define restricted firewall/iptables rules.
+     - ufw: apply the pre-defined firewall rules
+     - superuser-init: create the superuser based on en vars as soon as the taiga is up and running
 
 ## Building
 

--- a/grid3_taiga/README.md
+++ b/grid3_taiga/README.md
@@ -21,7 +21,10 @@ Easiest way to convert the docker image to Flist is using [Docker Hub Converter 
 
 ### Deploying
 Easiest way to deploy a VM using the flist is to head to to our [playground](https://play.grid.tf) and deploy a Virtual Machine by providing this flist URL.
-make sure to provide the correct entrypoint.
+* make sure to provide the correct entrypoint, and required env vars.
+* another important perquisite is to have a disk mounted on `/var/lib/docker`. make sure its size is big enough to fit both the images for taiga, and the volumes which will store all the db and the media files, etc.
+
+or use the dedicated Taiga weblet if available, which will deploy an instance that satisfies the above perquisites.
 
 another way you could use is using our terraform plugin [docs](https://github.com/threefoldtech/terraform-provider-grid)
 

--- a/grid3_taiga/README.md
+++ b/grid3_taiga/README.md
@@ -36,7 +36,7 @@ or use the dedicated Taiga weblet if available, which will deploy an instance th
 
 another way you could use is using our terraform plugin [docs](https://github.com/threefoldtech/terraform-provider-grid)
 
-here you can find a full terraform file example to deploy this flist on grid3 [link](https://github.com/threefoldtech/terraform-provider-grid/tree/development/examples/resources) 
+here you can find a full terraform file example to deploy this flist on grid3 [link](https://github.com/threefoldtech/terraform-provider-grid/blob/development/examples/resources/taiga/main.tf) 
 
 ## Flist
 ### URL:
@@ -61,6 +61,10 @@ https://hub.grid.tf/samehabouelsaad.3bot/abouelsaad-grid3_taiga_docker-latest.fl
 - `ADMIN_EMAIL`: email address for admin user.
 
 #### smtp server settings
+
+caution: configure smtp settings bellow **only If** you have an working smtp service and you know what you’re doing.
+otherwise don't set thoses or leave these settings empty. set wrong smtp settings will cause **issues/server errors in taiga**.
+
 - `DEFAULT_FROM_EMAIL`: the from email shown when sent emails to taiga members.
 - `EMAIL_USE_TLS`: either "True" or "False".
 - `EMAIL_USE_SSL`: either "True" or "False".

--- a/grid3_taiga/docker/docker-compose-smtp.yml
+++ b/grid3_taiga/docker/docker-compose-smtp.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 
 x-environment:
-  &default-back-environment
+  &smtp-back-environment
   # Email settings. 
   EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
   DEFAULT_FROM_EMAIL: "${DEFAULT_FROM_EMAIL}"
@@ -11,3 +11,10 @@ x-environment:
   EMAIL_PORT: "${EMAIL_PORT}"
   EMAIL_HOST_USER: "${EMAIL_HOST_USER}"
   EMAIL_HOST_PASSWORD: "${EMAIL_HOST_PASSWORD}"
+
+services:
+  taiga-back:
+    environment: *smtp-back-environment
+  
+  taiga-async:
+    environment: *smtp-back-environment

--- a/grid3_taiga/docker/docker-compose-smtp.yml
+++ b/grid3_taiga/docker/docker-compose-smtp.yml
@@ -1,0 +1,13 @@
+version: "3.5"
+
+x-environment:
+  &default-back-environment
+  # Email settings. 
+  EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
+  DEFAULT_FROM_EMAIL: "${DEFAULT_FROM_EMAIL}"
+  EMAIL_USE_TLS: "${EMAIL_USE_TLS}"
+  EMAIL_USE_SSL: "${EMAIL_USE_SSL}"
+  EMAIL_HOST: "${EMAIL_HOST}"
+  EMAIL_PORT: "${EMAIL_PORT}"
+  EMAIL_HOST_USER: "${EMAIL_HOST_USER}"
+  EMAIL_HOST_PASSWORD: "${EMAIL_HOST_PASSWORD}"

--- a/grid3_taiga/docker/docker-compose.yml
+++ b/grid3_taiga/docker/docker-compose.yml
@@ -9,8 +9,8 @@ x-environment:
   POSTGRES_HOST: taiga-db
   # Taiga settings
   TAIGA_SECRET_KEY: "taiga-back-secret-key"
-  TAIGA_SITES_SCHEME: "http"
-  TAIGA_SITES_DOMAIN: taiga-gateway:9000
+  TAIGA_SITES_SCHEME: "https"
+  TAIGA_SITES_DOMAIN: ${DOMAIN_NAME}
   TAIGA_SUBPATH: "" # or "/subpath"
   # Email settings. Uncomment following lines and configure your SMTP server
   # EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"

--- a/grid3_taiga/docker/docker-compose.yml
+++ b/grid3_taiga/docker/docker-compose.yml
@@ -1,0 +1,163 @@
+version: "3.5"
+
+x-environment:
+  &default-back-environment
+  # Database settings
+  POSTGRES_DB: taiga
+  POSTGRES_USER: taiga
+  POSTGRES_PASSWORD: taiga
+  POSTGRES_HOST: taiga-db
+  # Taiga settings
+  TAIGA_SECRET_KEY: "taiga-back-secret-key"
+  TAIGA_SITES_SCHEME: "http"
+  TAIGA_SITES_DOMAIN: taiga-gateway:9000
+  TAIGA_SUBPATH: "" # or "/subpath"
+  # Email settings. Uncomment following lines and configure your SMTP server
+  # EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
+  # DEFAULT_FROM_EMAIL: "no-reply@example.com"
+  # EMAIL_USE_TLS: "False"
+  # EMAIL_USE_SSL: "False"
+  # EMAIL_HOST: "smtp.host.example.com"
+  # EMAIL_PORT: 587
+  # EMAIL_HOST_USER: "user"
+  # EMAIL_HOST_PASSWORD: "password"
+  # Rabbitmq settings
+  # Should be the same as in taiga-async-rabbitmq and taiga-events-rabbitmq
+  RABBITMQ_USER: taiga
+  RABBITMQ_PASS: taiga
+  # RabbitMQ Fixes
+  CELERY_BROKER_URL: "amqp://taiga:taiga@taiga-async-rabbitmq:5672/taiga"
+  EVENTS_PUSH_BACKEND: "taiga.events.backends.rabbitmq.EventsPushBackend"
+  EVENTS_PUSH_BACKEND_URL: "amqp://taiga:taiga@taiga-events-rabbitmq:5672/taiga"
+  # Telemetry settings
+  ENABLE_TELEMETRY: "True"
+  # TF Connect settings
+  ENABLE_THREEFOLD: "True"
+  THREEFOLD_API_APP_SECRET : "2W/qhWFeMF6XawIPuEnJ3dWge49bYZNhSsELF64daus="
+  THREEFOLD_URL : "https://login.threefold.me"
+  THREEFOLD_OPENKYC_URL: "https://openkyc.live/verification/verify-sei"
+
+x-volumes:
+  &default-back-volumes
+  - taiga-static-data:/taiga-back/static
+  - taiga-media-data:/taiga-back/media
+  # - ./config.py:/taiga-back/settings/config.py
+
+
+services:
+  taiga-db:
+    image: postgres:12.3
+    environment:
+      POSTGRES_DB: taiga
+      POSTGRES_USER: taiga
+      POSTGRES_PASSWORD: taiga
+    volumes:
+      - taiga-db-data:/var/lib/postgresql/data
+    networks:
+      - taiga
+
+  taiga-back:
+    image: threefolddev/taiga-back-threefold:latest
+    environment: *default-back-environment
+    volumes: *default-back-volumes
+    networks:
+      - taiga
+    depends_on:
+      - taiga-db
+      - taiga-events-rabbitmq
+      - taiga-async-rabbitmq
+
+  taiga-async:
+    image: taigaio/taiga-back:latest
+    entrypoint: ["/taiga-back/docker/async_entrypoint.sh"]
+    environment: *default-back-environment
+    volumes: *default-back-volumes
+    networks:
+      - taiga
+    depends_on:
+      - taiga-db
+      - taiga-back
+      - taiga-async-rabbitmq
+
+  taiga-async-rabbitmq:
+    image: rabbitmq:3.8-management-alpine
+    environment:
+      RABBITMQ_ERLANG_COOKIE: secret-erlang-cookie
+      RABBITMQ_DEFAULT_USER: taiga
+      RABBITMQ_DEFAULT_PASS: taiga
+      RABBITMQ_DEFAULT_VHOST: taiga
+    volumes:
+      - taiga-async-rabbitmq-data:/var/lib/rabbitmq
+    networks:
+      - taiga
+
+  taiga-front:
+    image: threefolddev/taiga-front-threefold:latest
+    environment:
+      TAIGA_URL: "https://${DOMAIN_NAME}"
+      TAIGA_WEBSOCKETS_URL: "wss://${DOMAIN_NAME}"
+      TAIGA_SUBPATH: ""
+      ENABLE_THREEFOLD: "true"
+      THREEFOLD_URL : "https://login.threefold.me"
+      THREEFOLD_APP_ID: ""
+      THREEFOLD_API_APP_PUBLIC_KEY : "K4nQYVJJrcV0Y/6QuqeM3FKPGffdKC5/3HpOa/BmewY="
+    networks:
+      - taiga
+    # volumes:
+    #   - ./conf.json:/usr/share/nginx/html/conf.json
+
+  taiga-events:
+    image: taigaio/taiga-events:latest
+    environment:
+      RABBITMQ_USER: taiga
+      RABBITMQ_PASS: taiga
+      TAIGA_SECRET_KEY: "taiga-back-secret-key"
+    networks:
+      - taiga
+    depends_on:
+      - taiga-events-rabbitmq
+
+  taiga-events-rabbitmq:
+    image: rabbitmq:3.8-management-alpine
+    environment:
+      RABBITMQ_ERLANG_COOKIE: secret-erlang-cookie
+      RABBITMQ_DEFAULT_USER: taiga
+      RABBITMQ_DEFAULT_PASS: taiga
+      RABBITMQ_DEFAULT_VHOST: taiga
+    volumes:
+      - taiga-events-rabbitmq-data:/var/lib/rabbitmq
+    networks:
+      - taiga
+
+  taiga-protected:
+    image: taigaio/taiga-protected:latest
+    environment:
+      MAX_AGE: 360
+      SECRET_KEY: "taiga-back-secret-key"
+    networks:
+      - taiga
+
+  taiga-gateway:
+    image: nginx:1.19-alpine
+    ports:
+      - "9000:80"
+    volumes:
+      - ./taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
+      - taiga-static-data:/taiga/static
+      - taiga-media-data:/taiga/media
+    networks:
+      - taiga
+    depends_on:
+      - taiga-front
+      - taiga-back
+      - taiga-events
+
+volumes:
+  taiga-static-data:
+  taiga-media-data:
+  taiga-db-data:
+  taiga-async-rabbitmq-data:
+  taiga-events-rabbitmq-data:
+
+networks:
+  taiga:

--- a/grid3_taiga/docker/taiga-gateway/taiga.conf
+++ b/grid3_taiga/docker/taiga-gateway/taiga.conf
@@ -1,0 +1,75 @@
+server {
+    listen 80 default_server;
+
+    client_max_body_size 100M;
+    charset utf-8;
+
+    # Frontend
+    location / {
+        proxy_pass http://taiga-front/;
+        proxy_pass_header Server;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+    }
+
+    # API
+    location /api/ {
+        proxy_pass http://taiga-back:8000/api/;
+        proxy_pass_header Server;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+    }
+
+    # Admin
+    location /admin/ {
+        proxy_pass http://taiga-back:8000/admin/;
+        proxy_pass_header Server;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+    }
+
+    # Static
+    location /static/ {
+        alias /taiga/static/;
+    }
+
+    # Media
+    location /_protected/ {
+        internal;
+        alias /taiga/media/;
+        add_header Content-disposition "attachment";
+    }
+
+    # Unprotected section
+    location /media/exports/ {
+        alias /taiga/media/exports/;
+        add_header Content-disposition "attachment";
+    }
+
+    location /media/ {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://taiga-protected:8003/;
+        proxy_redirect off;
+    }
+
+    # Events
+    location /events {
+        proxy_pass http://taiga-events:8888/events;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_connect_timeout 7d;
+        proxy_send_timeout 7d;
+        proxy_read_timeout 7d;
+    }
+}

--- a/grid3_taiga/scripts/docker.sh
+++ b/grid3_taiga/scripts/docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo -500 >/proc/self/oom_score_adj
+exec /usr/bin/dockerd -H unix:// --containerd=/run/containerd/containerd.sock

--- a/grid3_taiga/scripts/sshd_init.sh
+++ b/grid3_taiga/scripts/sshd_init.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p ~/.ssh
+mkdir -p /var/run/sshd
+chmod 600 ~/.ssh
+chmod 600 /etc/ssh/*
+echo $SSH_KEY >> ~/.ssh/authorized_keys

--- a/grid3_taiga/scripts/superuser_init.sh
+++ b/grid3_taiga/scripts/superuser_init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+script="
+from taiga.users.models import User
+
+username = '$ADMIN_USERNAME'
+password = '$ADMIN_PASSWORD'
+email = '$ADMIN_EMAIL'
+
+if User.objects.filter(username=username).count()==0:
+    User.objects.create_superuser(username, email, password)
+    print('Superuser created.')
+else:
+    print('Username exists. Superuser creation skipped.')
+"
+
+if [ -z "$ADMIN_USERNAME" ] || [ -z "$ADMIN_EMAIL" ] || [ -z "$ADMIN_PASSWORD" ]; then
+        echo "Error: Missing required env vars! Superuser creation skipped."
+        exit 1
+else
+        while ! ps aux | grep [t]aiga.wsgi:application -q; do
+                sleep 30
+        done
+
+        docker exec docker_taiga-back_1 bash -c "printf \"$script\" | DJANGO_SETTINGS_MODULE=settings.config python manage.py shell"
+fi

--- a/grid3_taiga/scripts/taiga.sh
+++ b/grid3_taiga/scripts/taiga.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+export COMPOSE_HTTP_TIMEOUT=800
+set -x
+while ! docker info > /dev/null 2>&1; do
+    sleep 2
+done
+exec docker-compose -f /docker/docker-compose.yml up $@
+

--- a/grid3_taiga/scripts/taiga.sh
+++ b/grid3_taiga/scripts/taiga.sh
@@ -5,5 +5,10 @@ set -x
 while ! docker info > /dev/null 2>&1; do
     sleep 2
 done
-exec docker-compose -f /docker/docker-compose.yml up $@
 
+if [ -z "$DEFAULT_FROM_EMAIL" ] || [ -z "$EMAIL_USE_TLS" ] || [ -z "$EMAIL_USE_SSL" ] || [ -z "$EMAIL_HOST" ] || [ -z "$EMAIL_PORT" ] || [ -z "$EMAIL_HOST_USER" ] || [ -z "$EMAIL_HOST_PASSWORD" ]; then
+    echo "Warning: Missing required env vars for smtp service! Email notifications will not be sent and will be only shown in the stdout"
+    exec docker-compose -f /docker/docker-compose.yml up $@
+else
+    exec docker-compose -f /docker/docker-compose-smtp.yml -f /docker/docker-compose.yml up $@
+fi

--- a/grid3_taiga/scripts/ufw_init.sh
+++ b/grid3_taiga/scripts/ufw_init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow ssh
+ufw allow 9000
+ufw limit ssh
+

--- a/grid3_taiga/zinit_services/containerd.yaml
+++ b/grid3_taiga/zinit_services/containerd.yaml
@@ -1,0 +1,3 @@
+exec: /usr/bin/containerd
+after:
+  - ufw

--- a/grid3_taiga/zinit_services/dockerd.yaml
+++ b/grid3_taiga/zinit_services/dockerd.yaml
@@ -1,0 +1,3 @@
+exec: /scripts/docker.sh
+after:
+  - containerd

--- a/grid3_taiga/zinit_services/sshd-init.yaml
+++ b/grid3_taiga/zinit_services/sshd-init.yaml
@@ -1,0 +1,2 @@
+exec: /scripts/sshd_init.sh
+oneshot: true

--- a/grid3_taiga/zinit_services/sshd.yaml
+++ b/grid3_taiga/zinit_services/sshd.yaml
@@ -1,0 +1,4 @@
+exec: /usr/sbin/sshd -D
+# test: ps aux | grep "[s]shd"
+after:
+  - sshd-init

--- a/grid3_taiga/zinit_services/superuser-init.yaml
+++ b/grid3_taiga/zinit_services/superuser-init.yaml
@@ -1,0 +1,5 @@
+exec: /scripts/create_superuser.sh
+after:
+  - dockerd
+  - taiga
+oneshot: true

--- a/grid3_taiga/zinit_services/superuser-init.yaml
+++ b/grid3_taiga/zinit_services/superuser-init.yaml
@@ -1,5 +1,2 @@
-exec: /scripts/create_superuser.sh
-after:
-  - dockerd
-  - taiga
+exec: /scripts/superuser_init.sh
 oneshot: true

--- a/grid3_taiga/zinit_services/taiga.yaml
+++ b/grid3_taiga/zinit_services/taiga.yaml
@@ -1,0 +1,3 @@
+exec: /scripts/taiga.sh
+after:
+  - dockerd

--- a/grid3_taiga/zinit_services/ufw-init.yaml
+++ b/grid3_taiga/zinit_services/ufw-init.yaml
@@ -1,0 +1,3 @@
+exec: /scripts/ufw_init.sh
+oneshot: true
+

--- a/grid3_taiga/zinit_services/ufw.yaml
+++ b/grid3_taiga/zinit_services/ufw.yaml
@@ -1,0 +1,4 @@
+exec: ufw --force enable
+oneshot: true
+after:
+  - ufw-init


### PR DESCRIPTION
implement https://github.com/threefoldtech/grid_weblets/issues/409
image for taiga Standard installation, up and running in less than 5 minutes (initializations time), plus deploying time.
- TF connect integrated
- planetary network support
- Automate the superuser creation
- based on ubuntu 20.04
- use UFW firewall with restricted rules.
- use zinit process manager, which is configured with these services:
     - sshd: starting OpenSSH server daemon 
     - contained: starting containerd daemon, which manages the complete docker containers lifecycle.
     - dockerd: starting the Docker daemon.
     - taiga: Define different taiga services/containers, and spin everything up. 
     - sshd-init: Add the user SSH key to authorized_keys, so he can log in remotely to the host which running this image.
     - ufw-init: define restricted firewall/iptables rules.
     - ufw: apply the pre-defined firewall rules
     - superuser-init: create the superuser based on en vars as soon as the taiga is up and running



 