### PR TITLE
Raise default ulimit for nofile for docker and Owncloud services (OC, Mariadb and Redis)

### DIFF
--- a/tfgrid3/owncloud/docker/docker-compose.yml
+++ b/tfgrid3/owncloud/docker/docker-compose.yml
@@ -18,6 +18,10 @@ services:
     depends_on:
       - mariadb
       - redis
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     environment:
       - OWNCLOUD_DOMAIN=${OWNCLOUD_HOST}
       # ------------------------------------------------------------------------
@@ -61,6 +65,10 @@ services:
     image: mariadb:10.5
     container_name: owncloud_mariadb
     restart: always
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     environment:
       - MYSQL_ROOT_PASSWORD=owncloud
       - MYSQL_USER=owncloud
@@ -79,6 +87,10 @@ services:
     image: redis:6
     container_name: owncloud_redis
     restart: always
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     command: ["--databases", "1"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/tfgrid3/owncloud/scripts/docker.sh
+++ b/tfgrid3/owncloud/scripts/docker.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 echo -500 >/proc/self/oom_score_adj
+ulimit -Hn 1048576
+ulimit -Sn 1048576
 exec /usr/bin/dockerd -H unix:// --containerd=/run/containerd/containerd.sock


### PR DESCRIPTION
**What's changed**:
-  increasing nofile ulimit for the dockerd for performance and stability reasons
- increasing nofile ulimit for the OC, MariaDB, and Redis.

**Related issues**:
https://github.com/threefoldtech/owncloud_deployer/issues/38