### PR TITLE
Update k3s image

### DIFF
--- a/tfgrid3/k3s/manifests/traefik.yaml
+++ b/tfgrid3/k3s/manifests/traefik.yaml
@@ -8,7 +8,7 @@ spec:
   repo: https://helm.traefik.io/traefik
   valuesContent: |-
     image:
-      tag: 2.4.8
+      tag: 2.7.0
     additionalArguments:
       - "--certificatesresolvers.default.acme.tlschallenge"
       - "--certificatesresolvers.default.acme.email=dsafsdajfksdhfkjadsfoo@you.com"

--- a/tfgrid3/k3s/scripts/entrypoint.sh
+++ b/tfgrid3/k3s/scripts/entrypoint.sh
@@ -4,7 +4,7 @@ if [ -z "${K3S_DATA_DIR}" ]; then
     K3S_DATA_DIR=""
 else
     cp -r /var/lib/rancher/k3s/* $K3S_DATA_DIR
-    K3S_DATA_DIR="--data-dir $K3S_DATA_DIR"
+    K3S_DATA_DIR="--data-dir $K3S_DATA_DIR --kubelet-arg=root-dir=$K3S_DATA_DIR/kubelet"
 fi
 
 if [ -z "${K3S_FLANNEL_IFACE}" ]; then


### PR DESCRIPTION
### Changes

- Update traefik version to be compatible with k3s version 1.22
- Change the kubelet dir to be on the added disk

### Related issues

- #83 