### PR TITLE
Development Nextcloud AIO Image

### DIFF
--- a/tfgrid3/nextcloud/Dockerfile
+++ b/tfgrid3/nextcloud/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:22.04
+
+RUN apt update && \
+  apt -y install wget openssh-server curl sudo ufw
+
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
+  chmod +x /sbin/zinit
+
+RUN curl -fsSL https://get.docker.com -o /usr/local/bin/install-docker.sh && \
+    chmod +x /usr/local/bin/install-docker.sh
+
+RUN sh /usr/local/bin/install-docker.sh
+
+COPY ./scripts/ /scripts/
+COPY ./zinit/ /etc/zinit/
+RUN chmod +x /sbin/zinit && chmod +x /scripts/*.sh
+
+ENTRYPOINT ["/sbin/zinit", "init"]

--- a/tfgrid3/nextcloud/README.md
+++ b/tfgrid3/nextcloud/README.md
@@ -18,6 +18,12 @@ This Nextcloud All-in-One (AIO) FList can be deployed on a micro VM on the Three
 
 To simply deploy the available FList on the ThreeFold Playground, skip to [this section](#playground-steps).
 
+Note that the official FList for Nextcloud All-in-One is the following:
+
+```
+https://hub.grid.tf/tf-official-apps/threefoldtech-nextcloudaio-latest.flist
+```
+
 ***
 
 ## Create the Docker Image
@@ -88,7 +94,7 @@ You could also use Terraform instead of the Playground to deploy the Nextcloud A
           ```
       * Example:
         * ```
-          https://hub.grid.tf/idrnd.3bot/logismosis-nextcloudaio-latest.flist
+          https://hub.grid.tf/tf-official-apps/threefoldtech-nextcloudaio-latest.flist
           ```
   * Under `Entry Point`, the following should be set by default: `/sbin/zinit init`
   * Under `Root File System (GB)`, choose at least 8 GB.
@@ -123,6 +129,8 @@ You could also use Terraform instead of the Playground to deploy the Nextcloud A
     * ```
       https://dnschecker.org/#A/<domain-name>
       ```
+
+Note that you can also use DDNS services such as [DuckDNS](https://www.duckdns.org/) for a domain name.
 
 ## Conclusion
 

--- a/tfgrid3/nextcloud/README.md
+++ b/tfgrid3/nextcloud/README.md
@@ -7,6 +7,7 @@
 - [Convert the Docker Image to Zero-OS FList](#convert-the-docker-image-to-zero-os-flist)
 - [TFGrid Deployment](#tfgrid-deployment)
   - [Playground Steps](#playground-steps)
+  - [Set the DNS Record for Your Domain](#set-the-dns-record-for-your-domain)
 - [Conclusion](#conclusion)
 
 ***
@@ -101,6 +102,26 @@ You could also use Terraform instead of the Playground to deploy the Nextcloud A
     ```
   * It might take a couple of minutes to start the Nextcloud instance
 * Follow the Nextcloud AIO steps
+
+### Set the DNS Record for Your Domain
+
+* Go to your domain name registrar (e.g. Namecheap)
+  * In the section Advanced DNS, add a DNS A Record to your domain (both @ and www as hosts) and link it with the VM IP Address
+    * Record with @ as host
+      * Type: A Record
+      * Host: @
+      * Value: VM IP Address
+      * TTL: Automatic
+    * Record with www as host
+      * Type: A Record
+      * Host: www
+      * Value: VM IP Address
+      * TTL: Automatic
+  * It might take up to 30 minutes to set the DNS properly.
+  * To check if the A record has been registered, you can use a common DNS checker:
+    * ```
+      https://dnschecker.org/#A/<domain-name>
+      ```
 
 ## Conclusion
 

--- a/tfgrid3/nextcloud/README.md
+++ b/tfgrid3/nextcloud/README.md
@@ -99,7 +99,7 @@ You could also use Terraform instead of the Playground to deploy the Nextcloud A
 * Click `Deploy`.
 * Go to the following URL:
   * ```
-    <VM_IPv4_Address>:8080
+    https://<VM_IPv4_Address>:8080
     ```
   * It might take a couple of minutes to start the Nextcloud instance
 * Follow the Nextcloud AIO steps

--- a/tfgrid3/nextcloud/README.md
+++ b/tfgrid3/nextcloud/README.md
@@ -88,7 +88,7 @@ You could also use Terraform instead of the Playground to deploy the Nextcloud A
           ```
       * Example:
         * ```
-          https://hub.grid.tf/idrnd.3bot/logismosis-nextcloud-aio2-latest.flist
+          https://hub.grid.tf/idrnd.3bot/logismosis-nextcloudaio-latest.flist
           ```
   * Under `Entry Point`, the following should be set by default: `/sbin/zinit init`
   * Under `Root File System (GB)`, choose at least 8 GB.

--- a/tfgrid3/nextcloud/README.md
+++ b/tfgrid3/nextcloud/README.md
@@ -1,0 +1,109 @@
+<h1> Nextcloud All-in-One </h1>
+
+<h2> Table of Contents </h2>
+
+- [Introduction](#introduction)
+- [Create the Docker Image](#create-the-docker-image)
+- [Convert the Docker Image to Zero-OS FList](#convert-the-docker-image-to-zero-os-flist)
+- [TFGrid Deployment](#tfgrid-deployment)
+  - [Playground Steps](#playground-steps)
+- [Conclusion](#conclusion)
+
+***
+
+## Introduction
+
+This Nextcloud All-in-One (AIO) FList can be deployed on a micro VM on the ThreeFold Grid, either via the TF Playground, or Terraform. This FList uses `Ubuntu 22.04` and also includes the preinstalled `openssh-server` package. Docker is installed directly from [www.get.docker.com](https://get.docker.com/). This FList  Nextcloud All-in-One is installed based on the latest Nextcloud All-in-One release from the Docker Hub.
+
+To simply deploy the available FList on the ThreeFold Playground, skip to [this section](#playground-steps).
+
+***
+
+## Create the Docker Image
+
+To create the the Nextcloud AIO image, clone this repository, then build and push the image to the Docker Hub.
+
+* Clone the repository:
+  * ```
+    git clone https://github.com/threefoldtech/tf-images
+    ```
+  * ```
+    cd tf-images
+    ```
+* Build the image:
+  * ```
+    docker build -t <docker_username>/<docker_repo_name> .
+    ```
+* Push the image to the Docker Hub:
+  * ```
+    docker push <your_username>/<docker_repo_name>
+    ```
+ 
+***
+
+## Convert the Docker Image to Zero-OS FList
+
+The easiest way to convert the docker image to an FList is by using the [Docker Hub Converter Tool](https://hub.grid.tf/docker-convert). This can be done once you've built and pushed the docker image on the [Docker Hub](https://hub.docker.com/).
+
+> Note: A docker image has already been converted to an FList (see below).
+
+* Go to the [ThreeFold Hub](https://hub.grid.tf/).
+* Sign in with the ThreeFold Connect app.
+* Go to the [Docker Hub Converter](https://hub.grid.tf/docker-convert) section.
+* Next to `Docker Image Name`, add the docker image repository and name, see the example below:
+  * Template:
+    * `<docker_username>/docker_image_name:tagname`
+* Click `Convert the docker image`.
+* Once the conversion is done, the FList is available as a public link on the ThreeFold Hub.
+* To get the FList URL, go to the [TF Hub main page](https://hub.grid.tf/), scroll down to your 3Bot ID and click on it.
+* Under `Name`, you will see all your available FLists.
+* Right-click on the FList you want and select `Copy Clean Link`. This URL will be used when deploying on the ThreeFold Playground. We show below the template and an example of what the FList URL looks like.
+  * Template:
+    * ```
+      https://hub.grid.tf/<3BOT_name.3bot>/<docker_username>-<docker_image_name>-<tagname>.flist
+      ```
+
+***
+## TFGrid Deployment
+
+The easiest way to deploy a micro VM using the Nextcloud AIO FList is to head to to the [ThreeFold Playground](https://play.grid.tf) and deploy a [Micro Virtual Machine](https://play.grid.tf/#/vm) by providing the FList URL. Make sure to select `IPv4`.
+
+Make sure to provide the correct entrypoint (`/sbin/zinit init`). Note that the entrypoint should already be set by default when you open the micro VM page. 
+
+You could also use Terraform instead of the Playground to deploy the Nextcloud AIO Micro VM. Read more on this [here](https://github.com/threefoldtech/terraform-provider-grid).
+
+### Playground Steps
+
+* Go to the [ThreeFold Playground](https://play.grid.tf)
+* Log into your TF wallet
+* Go to the [Micro VM](https://play.grid.tf/#/vm) page
+* In the section `Config`, 
+  * Choose a name for your VM under `Name`.
+  * Under `VM Image`, select `Other`.
+    * Enter the Debian FList under `FList`:
+      * Template:
+        * ```
+          https://hub.grid.tf/<3BOT_name.3bot>/<docker_username>-<docker_image_name>-<tagname>.flist
+          ```
+      * Example:
+        * ```
+          https://hub.grid.tf/idrnd.3bot/logismosis-nextcloudaio-5-latest.flist
+          ```
+  * Under `Entry Point`, the following should be set by default: `/sbin/zinit init`
+  * Under `CPU (vCores)`, choose at least 2 vCores (minimum).
+  * Under `Memory (MB)`, choose at least 4096 MB of RAM (minimum).
+  * Make sure that `Public IPv4` is enabled (required).
+* In the section `Disks`, click on the `+` button and choose at least 50 GB of storage  under `Size (GB)`.
+* Click `Deploy`.
+* Go to the following URL:
+  * ```
+    <VM_IPv4_Address>:8080
+    ```
+  * It might take a couple of minutes to start the Nextcloud instance
+* Follow the Nextcloud AIO steps
+
+## Conclusion
+
+We've seen the overall process of creating a new FList to deploy a Nextcloud AIO workload on a Micro VM on the ThreeFold Playground.
+
+If you have any questions or feedback, please let us know by either writing a post on the [ThreeFold Forum](https://forum.threefold.io/), or by chatting with us on the [TF Grid Tester Community](https://t.me/threefoldtesting) Telegram channel.

--- a/tfgrid3/nextcloud/README.md
+++ b/tfgrid3/nextcloud/README.md
@@ -88,7 +88,7 @@ You could also use Terraform instead of the Playground to deploy the Nextcloud A
           ```
       * Example:
         * ```
-          https://hub.grid.tf/idrnd.3bot/logismosis-nextcloudaio-5-latest.flist
+          https://hub.grid.tf/idrnd.3bot/logismosis-nextcloud-aio2-latest.flist
           ```
   * Under `Entry Point`, the following should be set by default: `/sbin/zinit init`
   * Under `Root File System (GB)`, choose at least 8 GB.

--- a/tfgrid3/nextcloud/README.md
+++ b/tfgrid3/nextcloud/README.md
@@ -91,6 +91,7 @@ You could also use Terraform instead of the Playground to deploy the Nextcloud A
           https://hub.grid.tf/idrnd.3bot/logismosis-nextcloudaio-5-latest.flist
           ```
   * Under `Entry Point`, the following should be set by default: `/sbin/zinit init`
+  * Under `Root File System (GB)`, choose at least 8 GB.
   * Under `CPU (vCores)`, choose at least 2 vCores (minimum).
   * Under `Memory (MB)`, choose at least 4096 MB of RAM (minimum).
   * Make sure that `Public IPv4` is enabled (required).

--- a/tfgrid3/nextcloud/scripts/nextcloud.sh
+++ b/tfgrid3/nextcloud/scripts/nextcloud.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "Before docker info sleep loop." >> /usr/local/bin/nextcloud_installation.md
+
+export COMPOSE_HTTP_TIMEOUT=800
+set -x
+while ! docker info > /dev/null 2>&1; do
+    sleep 2
+done
+
+echo "After docker info sleep loop." >> /usr/local/bin/nextcloud_installation.md
+
+docker run \
+--sig-proxy=false \
+--name nextcloud-aio-mastercontainer \
+--restart always \
+--publish 80:80 \
+--publish 8080:8080 \
+--publish 8443:8443 \
+--volume nextcloud_aio_mastercontainer:/mnt/docker-aio-config \
+--volume /var/run/docker.sock:/var/run/docker.sock:ro \
+nextcloud/all-in-one:latest

--- a/tfgrid3/nextcloud/scripts/sshd_init.sh
+++ b/tfgrid3/nextcloud/scripts/sshd_init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "ssh is not yet set." >> /usr/local/bin/nextcloud_installation.md
+
+mkdir -p ~/.ssh
+mkdir -p /var/run/sshd
+chmod 600 ~/.ssh
+chmod 600 /etc/ssh/*
+echo $SSH_KEY >> ~/.ssh/authorized_keys
+
+echo "ssh is set." >> /usr/local/bin/nextcloud_installation.md

--- a/tfgrid3/nextcloud/scripts/ufw_init.sh
+++ b/tfgrid3/nextcloud/scripts/ufw_init.sh
@@ -10,6 +10,7 @@ ufw allow ssh
 ufw allow http
 ufw allow https
 ufw allow 8443
+ufw allow 3478
 ufw limit ssh
 
 echo "ufw is set." >> /usr/local/bin/nextcloud_installation.md

--- a/tfgrid3/nextcloud/scripts/ufw_init.sh
+++ b/tfgrid3/nextcloud/scripts/ufw_init.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "ufw is not yet set." >> /usr/local/bin/nextcloud_installation.md
+
+set -x
+
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow ssh
+ufw allow http
+ufw allow https
+ufw allow 8443
+ufw limit ssh
+
+echo "ufw is set." >> /usr/local/bin/nextcloud_installation.md

--- a/tfgrid3/nextcloud/zinit/containerd.yaml
+++ b/tfgrid3/nextcloud/zinit/containerd.yaml
@@ -1,0 +1,3 @@
+exec: /usr/bin/containerd
+after:
+  - ufw

--- a/tfgrid3/nextcloud/zinit/dockerd.yaml
+++ b/tfgrid3/nextcloud/zinit/dockerd.yaml
@@ -1,0 +1,3 @@
+exec: /usr/bin/dockerd
+after:
+  - ufw

--- a/tfgrid3/nextcloud/zinit/dockerd.yaml
+++ b/tfgrid3/nextcloud/zinit/dockerd.yaml
@@ -1,3 +1,3 @@
 exec: /usr/bin/dockerd
 after:
-  - ufw
+  - containerd

--- a/tfgrid3/nextcloud/zinit/nextcloud.yaml
+++ b/tfgrid3/nextcloud/zinit/nextcloud.yaml
@@ -1,0 +1,3 @@
+exec: /scripts/nextcloud.sh
+after:
+  - dockerd

--- a/tfgrid3/nextcloud/zinit/ssh-init.yaml
+++ b/tfgrid3/nextcloud/zinit/ssh-init.yaml
@@ -1,0 +1,2 @@
+exec: /scripts/sshd_init.sh
+oneshot: true

--- a/tfgrid3/nextcloud/zinit/sshd.yaml
+++ b/tfgrid3/nextcloud/zinit/sshd.yaml
@@ -1,0 +1,3 @@
+exec: bash -c "/usr/sbin/sshd -D"
+after:
+  - ssh-init

--- a/tfgrid3/nextcloud/zinit/ufw-init.yaml
+++ b/tfgrid3/nextcloud/zinit/ufw-init.yaml
@@ -1,0 +1,3 @@
+exec: /scripts/ufw_init.sh
+oneshot: true
+

--- a/tfgrid3/nextcloud/zinit/ufw.yaml
+++ b/tfgrid3/nextcloud/zinit/ufw.yaml
@@ -1,0 +1,4 @@
+exec: ufw --force enable
+oneshot: true
+after:
+  - ufw-init


### PR DESCRIPTION
This is a Nextcloud All-in-One deployment. 

The user needs to:

* deploy the micro VM with the FList
* Set the domain advanced DNS A record
* Log to the Nextcloud AIO via the URL
   * <VM_IP_address>:8080 

(It's all explained in the README.md)

Next step would be to turn this into a Weblet on the [new Playground weblets repo](https://github.com/threefoldtech/tfgrid-sdk-ts/tree/development_nextcloud_weblet/packages/playground/src/weblets). (I would do it after we accept this PR.)

Please have a hard look at it and tell me if I can improve it in any way!

I don't mind putting this to draft if needed.

Advantages:

* Very easy to set up
* Can get email server running
* When the VM shuts down and reboots, the instance is accessible (always restart)
* Borgbackup (automatic backup) is integrated

Future projects:

* If we can link Borgbackup to a QSFS deployment, it would show one of the great aspects of the TFGrid.

Thanks!