### PR TITLE
added init line for docker run based on new nc update

### DIFF
--- a/tfgrid3/nextcloud/scripts/nextcloud.sh
+++ b/tfgrid3/nextcloud/scripts/nextcloud.sh
@@ -11,6 +11,7 @@ done
 echo "After docker info sleep loop." >> /usr/local/bin/nextcloud_installation.md
 
 docker run \
+--init \
 --sig-proxy=false \
 --name nextcloud-aio-mastercontainer \
 --restart always \


### PR DESCRIPTION
The Nextcloud github repo recently added a line to run Nextcloud with docker (--init). While the current flist will still work, this line might avoid potential issues. See the commit in question from nextcloud [here](https://github.com/nextcloud/all-in-one/commit/5621a456f937a7d9b3731e431a2a106a301feb45) and the [readme.md file](https://github.com/nextcloud/all-in-one#how-to-use-this).

I thus updated the Dockerfile of the nextcloud flist in this branch.

***

Once this is done, we will be able to (re-)promote the nextcloud flist to the official tf app. The flist in the hub.grid.tf is already updated with the new line (--init).

```
https://hub.grid.tf/idrnd.3bot/logismosis-nextcloudaio-latest.flist.md
```