### PR TITLE
Nextcloud gateway support and docker data on disk

### DIFF
--- a/tfgrid3/nextcloud/Caddyfile
+++ b/tfgrid3/nextcloud/Caddyfile
@@ -1,0 +1,50 @@
+{
+	order replace after encode
+	servers {
+		trusted_proxies static 100.64.0.0/10 10.0.0.0/8
+	}
+}
+
+
+{$DOMAIN}:{$PORT} {
+	handle_path /aio* {
+		replace {
+			href="/ href="/aio/
+			src="/ src="/aio/
+			action=" action="/aio
+			url(' url('/aio
+			`value="" placeholder="nextcloud.yourdomain.com"` `value="{$DOMAIN}"`
+			`"Submit domain"` `"Submit domain" id="domain-submit"` 
+			{$REPLACEMENTS}
+			<body> {$BODY}
+		}
+
+		reverse_proxy localhost:8000 {
+			header_down Location "^/(.*)$" "/aio/$1"
+			header_down Refresh "^/(.*)$" "/aio/$1"
+		}
+			
+	}
+
+	redir /api/auth/getlogin /aio{uri}
+
+	reverse_proxy localhost:11000
+
+	handle_errors {
+		@502-aio expression {err.status_code} == 502 && path('/aio*')
+		handle @502-aio {
+			header Content-Type text/html
+			respond <<HTML
+				<html>
+				  <head><title>Nextcloud</title></head>
+				  <body>Your Nextcloud management interface isn't ready. If you just deployed this instance, please wait a minute and refresh the page.</body>
+				</html>
+				HTML 200
+		}
+
+		@502 expression {err.status_code} == 502
+		handle @502 {
+			redir /* /aio
+		}
+	}
+}

--- a/tfgrid3/nextcloud/Dockerfile
+++ b/tfgrid3/nextcloud/Dockerfile
@@ -1,16 +1,20 @@
 FROM ubuntu:22.04
 
 RUN apt update && \
-  apt -y install wget openssh-server curl sudo ufw
+  apt -y install wget openssh-server curl sudo ufw inotify-tools iproute2
 
 RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
   chmod +x /sbin/zinit
 
+RUN wget -O /sbin/caddy 'https://caddyserver.com/api/download?os=linux&arch=amd64&p=github.com%2Fcaddyserver%2Freplace-response&idempotency=43631173212363' && \
+  chmod +x /sbin/caddy
+
 RUN curl -fsSL https://get.docker.com -o /usr/local/bin/install-docker.sh && \
-    chmod +x /usr/local/bin/install-docker.sh
+  chmod +x /usr/local/bin/install-docker.sh
 
 RUN sh /usr/local/bin/install-docker.sh
 
+COPY ./Caddyfile /etc/caddy/
 COPY ./scripts/ /scripts/
 COPY ./zinit/ /etc/zinit/
 RUN chmod +x /sbin/zinit && chmod +x /scripts/*.sh

--- a/tfgrid3/nextcloud/scripts/caddy.sh
+++ b/tfgrid3/nextcloud/scripts/caddy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+export DOMAIN=$NEXTCLOUD_DOMAIN
+
+if $IPV4 && ! $GATEWAY; then
+  export PORT=443
+else
+  export PORT=80
+fi
+
+if $IPV4; then
+  export BODY="\`<body onload=\"if (document.getElementById('domain-submit')) {document.getElementById('domain-submit').click()}\">\`"
+
+else
+  export BODY="\`<body onload=\"if (document.getElementById('domain-submit')) {document.getElementById('domain-submit').click()}; if (document.getElementById('talk') && document.getElementById('talk').checked) {document.getElementById('talk').checked = false; document.getElementById('options-form-submit').click()}\">\`"
+
+  export REPLACEMENTS='			`name="talk"` `name="talk" disabled`
+			`needs ports 3478/TCP and 3478/UDP open/forwarded in your firewall/router` `running the Talk container requires a public IP and this VM does not have one. It is still possible to use Talk in a limited capacity. Please consult the documentation for details`'
+fi
+
+caddy run --config /etc/caddy/Caddyfile

--- a/tfgrid3/nextcloud/scripts/nextcloud.sh
+++ b/tfgrid3/nextcloud/scripts/nextcloud.sh
@@ -1,22 +1,21 @@
 #!/bin/bash
 
-echo "Before docker info sleep loop." >> /usr/local/bin/nextcloud_installation.md
-
 export COMPOSE_HTTP_TIMEOUT=800
-set -x
 while ! docker info > /dev/null 2>&1; do
+    echo docker not ready
     sleep 2
 done
 
-echo "After docker info sleep loop." >> /usr/local/bin/nextcloud_installation.md
-
 docker run \
+--init \
 --sig-proxy=false \
 --name nextcloud-aio-mastercontainer \
 --restart always \
---publish 80:80 \
+--publish 8000:8000 \
 --publish 8080:8080 \
---publish 8443:8443 \
+--env APACHE_PORT=11000 \
+--env APACHE_IP_BINDING=0.0.0.0 \
+--env SKIP_DOMAIN_VALIDATION=true \
 --volume nextcloud_aio_mastercontainer:/mnt/docker-aio-config \
 --volume /var/run/docker.sock:/var/run/docker.sock:ro \
 nextcloud/all-in-one:latest

--- a/tfgrid3/nextcloud/scripts/nextcloud_conf.sh
+++ b/tfgrid3/nextcloud/scripts/nextcloud_conf.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Wait for the nextcloud container to become healthy. Note that we can set the
+# richtext config parameters even before the app is installed
+
+nc_ready () {
+  until [[ "`docker inspect -f {{.State.Health.Status}} nextcloud-aio-nextcloud 2> /dev/null`" == "healthy" ]]; do
+      sleep 1;
+  done;
+}
+
+# When a gateway is used, AIO sets the WOPI allow list to only include the
+# gateway IP. Since requests don't originate from the gateway IP, they are 
+# blocked by default. Here we add the public IP of the VM, or of the router 
+# upstream of the node
+# See: github.com/nextcloud/security-advisories/security/advisories/GHSA-24x8-h6m2-9jf2
+
+if $IPV4; then
+  interface=$(ip route show default | cut -d " " -f 5)
+  ipv4_address=$(ip a show $interface | grep -Po 'inet \K[\d.]+')
+fi
+
+if $GATEWAY; then
+  nc_ready
+  wopi_list=$(docker exec --user www-data nextcloud-aio-nextcloud php occ config:app:get richdocuments wopi_allowlist)
+
+  if $IPV4; then
+    ip=$ipv4_address
+  else
+    ip=$(curl -fs https://ipinfo.io/ip)
+  fi
+
+  if [[ $ip ]] && ! echo $wopi_list | grep -q $ip; then
+    docker exec --user www-data nextcloud-aio-nextcloud php occ config:app:set richdocuments wopi_allowlist --value=$ip
+  fi
+fi
+
+
+# If the VM has a gateway and a public IPv4, then AIO will set the STUN/TURN 
+# servers to the gateway domain which does not point to the public IP, so we  
+# use the IP instead. In this case, we must wait for the Talk app to be
+# installed before changing the settings. With inotifywait, we don't need
+# a busy loop that could run indefinitely
+
+apps_dir=/mnt/data/docker/volumes/nextcloud_aio_nextcloud/_data/custom_apps/
+
+if $GATEWAY && $IPV4; then
+  if [[ ! -d ${apps_dir}spreed ]]; then
+    inotifywait -qq -e create --include spreed $apps_dir
+  fi
+  nc_ready
+  
+  turn_list=$(docker exec --user www-data nextcloud-aio-nextcloud php occ talk:turn:list)
+  turn_secret=$(echo "$turn_list" | grep secret | cut -d " " -f 4)
+  turn_server=$(echo "$turn_list" | grep server | cut -d " " -f 4)
+  
+  if ! echo $turn_server | grep -q $ipv4_address; then
+    docker exec --user www-data nextcloud-aio-nextcloud php occ talk:turn:delete turn $turn_server udp,tcp
+    docker exec --user www-data nextcloud-aio-nextcloud php occ talk:turn:add turn $ipv4_address:3478 udp,tcp --secret=$turn_secret
+  fi
+  
+  stun_list=$(docker exec --user www-data nextcloud-aio-nextcloud php occ talk:stun:list)
+  stun_server=$(echo $stun_list | cut -d " " -f 2)
+  
+  if ! echo $stun_server | grep -q $ipv4_address; then
+    docker exec --user www-data nextcloud-aio-nextcloud php occ talk:stun:add $ipv4_address:3478
+    docker exec --user www-data nextcloud-aio-nextcloud php occ talk:stun:delete $stun_server
+  fi
+fi

--- a/tfgrid3/nextcloud/scripts/sshd_init.sh
+++ b/tfgrid3/nextcloud/scripts/sshd_init.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-echo "ssh is not yet set." >> /usr/local/bin/nextcloud_installation.md
-
 mkdir -p ~/.ssh
 mkdir -p /var/run/sshd
 chmod 600 ~/.ssh
 chmod 600 /etc/ssh/*
 echo $SSH_KEY >> ~/.ssh/authorized_keys
-
-echo "ssh is set." >> /usr/local/bin/nextcloud_installation.md

--- a/tfgrid3/nextcloud/scripts/ufw_init.sh
+++ b/tfgrid3/nextcloud/scripts/ufw_init.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-echo "ufw is not yet set." >> /usr/local/bin/nextcloud_installation.md
-
-set -x
-
 ufw default deny incoming
 ufw default allow outgoing
 ufw allow ssh
@@ -12,5 +8,3 @@ ufw allow https
 ufw allow 8443
 ufw allow 3478
 ufw limit ssh
-
-echo "ufw is set." >> /usr/local/bin/nextcloud_installation.md

--- a/tfgrid3/nextcloud/zinit/containerd.yaml
+++ b/tfgrid3/nextcloud/zinit/containerd.yaml
@@ -1,3 +1,0 @@
-exec: /usr/bin/containerd
-after:
-  - ufw

--- a/tfgrid3/nextcloud/zinit/dockerd.yaml
+++ b/tfgrid3/nextcloud/zinit/dockerd.yaml
@@ -1,3 +1,1 @@
-exec: /usr/bin/dockerd
-after:
-  - containerd
+exec: /usr/bin/dockerd --data-root /mnt/data/docker

--- a/tfgrid3/nextcloud/zinit/nextcloud-conf.yaml
+++ b/tfgrid3/nextcloud/zinit/nextcloud-conf.yaml
@@ -1,0 +1,4 @@
+exec: /scripts/nextcloud_conf.sh
+oneshot: true
+after:
+    - nextcloud


### PR DESCRIPTION
This PR updates the Nextcloud image as follows:

* Support access to both Nextcloud and the separate management "AIO" web interface via a single grid gateway, using Caddy as a reverse proxy
* Perform post deployment configuration as needed to support all combinations of public IP and gateway
* Move the Docker data directory to a disk attached to the micro VM, for better performance versus using the mandatory virtio driver on the rootfs