### PR TITLE
Update Nomad server image to have variable number of servers

### DIFF
--- a/tfgrid3/nomad/README.md
+++ b/tfgrid3/nomad/README.md
@@ -1,6 +1,6 @@
 # Description
 
-These are server and client images for [Nomad](https://www.nomadproject.io/) with the client supporting Docker task driver. Servers must be exactly 3 nodes while any number of clients are allowed.
+These are server and client images for [Nomad](https://www.nomadproject.io/) with the client supporting Docker task driver. The server image allows for multiple server setup using `NOMAD_SERVERS` environment variable.
 
 ## Environment Variables
 
@@ -8,6 +8,7 @@ Only two variables are expected to function properly:
 
 - "SSH_KEY": Public SSH key to be able to access different nodes. If not provided SSH won't work.
 - "FIRST_SERVER_IP": The private IP of the first server to be deployed. It should be provided for all nodes except the first server node. If not provided, the nodes won't be able to join the cluster.
+- "NOMAD_SERVERS": Number of expected nomad servers for the cluster to work. The cluster will not function if the servers are less than `NOMAD_SERVERS`. If not provided the default is 1. Check Nomad [docs](https://developer.hashicorp.com/nomad/docs/configuration/server#bootstrap_expect) for more info.
 
 ## Build flist
 

--- a/tfgrid3/nomad/server/ps/configure-node.yaml
+++ b/tfgrid3/nomad/server/ps/configure-node.yaml
@@ -6,7 +6,7 @@ exec: |
 
   server {
     enabled          = true
-    bootstrap_expect = 3
+    bootstrap_expect = ${NOMAD_SERVERS:-1}
   }
   EOF
   '


### PR DESCRIPTION
## Description 

Change the number of servers to be configurable using environment variable with a default of 1.

## Issues

- #181 