### PR TITLE
Add benchmark flist

### DIFF
--- a/tfgrid3/benchmark/README.md
+++ b/tfgrid3/benchmark/README.md
@@ -1,0 +1,40 @@
+# Benchmark
+
+A small flist used to benchmark nodes and how a normal workload would perform. It uses [cpubench](https://github.com/threefoldtech/cpu-benchmark-simple) and [fio](https://fio.readthedocs.io/en/latest/fio_doc.html) and pushes the result to an [influxdb](https://docs.influxdata.com/influxdb/v2/) instance.
+
+It depends on `jq` to parse json output of benchmarks and `crond` to run benchmarks periodically every 15 minutes.
+
+## How to use
+
+- Run `build.sh` with `sudo` and a tarball should be created called `benchmark.tar.gz`.
+- Upload the archive to hub.grid.tf with either the UI or curl with [API token](https://hub.grid.tf/token).
+
+## Environment Variables
+
+In order for this flist to work properly, a set of environment variables needs to be provided:
+
+- `INFLUX_URL`: URL of the running influxdb instance. Example: `influx.example.org:8086`
+- `INFLUX_ORG`: organization specified when running influxdb instance.
+- `INFLUX_TOKEN`: influxdb access token.
+- `INFLUX_BUCKET`: influxdb bucket where results will reside.
+- `NODE_ID`: node id of the running VM to filter results.
+- `FARM_ID`: farm id of the running VM to filter results.
+
+## Testing
+
+An instance of benchmark flist can be found [here](https://hub.grid.tf/aelawady.3bot/benchmark.flist.md). You will need to run it after deploying an influxdb instance and provide the needed environment variables.
+
+You can run an influxdb instance with docker like this
+
+```console
+$ docker run --rm --name influx -p 8086:8086 \            
+  -e DOCKER_INFLUXDB_INIT_MODE=setup \
+  -e DOCKER_INFLUXDB_INIT_USERNAME=abc \
+  -e DOCKER_INFLUXDB_INIT_PASSWORD=12345678 \
+  -e DOCKER_INFLUXDB_INIT_ORG=tf \
+  -e DOCKER_INFLUXDB_INIT_BUCKET=init \
+  -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=123 \
+  influxdb:2
+```
+
+For more details on influxdb docker image check out [influxdb](https://hub.docker.com/_/influxdb).

--- a/tfgrid3/benchmark/benchmark
+++ b/tfgrid3/benchmark/benchmark
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+. /root/.env
+
+cpudata=$(cpubench -j | jq '"single=\(.single),multi=\(.multi),threads=\(.threads)"' -r)
+
+
+curl --request POST \
+"${INFLUX_URL}/api/v2/write?org=${INFLUX_ORG}&bucket=${INFLUX_BUCKET}&precision=s" \
+--header "Authorization: Token ${INFLUX_TOKEN}" \
+--header "Content-Type: text/plain; charset=utf-8" \
+--header "Accept: application/json" \
+--data-binary "cpu,node=${NODE_ID},farm=${FARM_ID} ${cpudata} $(date +%s)"
+
+fiodata=$(fio --name=write_throughput --directory=/fio --numjobs=4 --size=1G --time_based --runtime=1m --ramp_time=2s --ioengine=libaio --direct=1 --verify=0 --bs=1M --iodepth=64 --rw=write --group_reporting=1 --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json+ | jq -r '"write_io_bytes=\(.jobs[0].write.io_bytes),
+write_bw_bytes=\(.jobs[0].write.bw_bytes),
+write_iops=\(.jobs[0].write.iops),
+write_latency_min_ns=\(.jobs[0].write.lat_ns.min),
+write_latency_max_ns=\(.jobs[0].write.lat_ns.max),
+write_latency_mean_ns=\(.jobs[0].write.lat_ns.mean)"'| tr -d '\n')
+
+rm -rf /fio/*
+
+curl --request POST \
+"${INFLUX_URL}/api/v2/write?org=${INFLUX_ORG}&bucket=${INFLUX_BUCKET}&precision=s" \
+--header "Authorization: Token ${INFLUX_TOKEN}" \
+--header "Content-Type: text/plain; charset=utf-8" \
+--header "Accept: application/json" \
+--data-binary "io,node=${NODE_ID},farm=${FARM_ID} ${fiodata} $(date +%s)"

--- a/tfgrid3/benchmark/build.sh
+++ b/tfgrid3/benchmark/build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+
+wget https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/x86_64/alpine-minirootfs-3.19.1-x86_64.tar.gz
+mkdir rootfs
+tar xf alpine-minirootfs-3.19.1-x86_64.tar.gz -C rootfs
+rm alpine-minirootfs-3.19.1-x86_64.tar.gz
+
+
+echo "nameserver 1.1.1.1" > rootfs/etc/resolv.conf
+
+
+mkdir rootfs/data rootfs/fio
+chroot rootfs sh <<EOF
+apk update
+apk add fio openssh jq curl
+EOF
+
+wget https://github.com/threefoldtech/cpu-benchmark-simple/releases/download/v0.1/grid-cpubench-simple-0.1-linux-amd64-static -O cpubench
+chmod +x cpubench
+mv cpubench rootfs/sbin/
+cp benchmark rootfs/etc/periodic/15min/
+
+# setup zinit
+wget https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit
+chmod +x zinit
+mv zinit rootfs/sbin/zinit
+
+mkdir rootfs/etc/zinit
+cp etc/zinit/* rootfs/etc/zinit/
+
+rm rootfs/etc/resolv.conf
+
+tar czf benchmark.tar.gz -C rootfs .
+
+rm -rf rootfs

--- a/tfgrid3/benchmark/etc/zinit/benchmark.yaml
+++ b/tfgrid3/benchmark/etc/zinit/benchmark.yaml
@@ -1,0 +1,4 @@
+exec: /etc/periodic/15min/benchmark
+oneshot: true
+after:
+  - write-env

--- a/tfgrid3/benchmark/etc/zinit/crond.yaml
+++ b/tfgrid3/benchmark/etc/zinit/crond.yaml
@@ -1,0 +1,1 @@
+exec: /usr/sbin/crond -f

--- a/tfgrid3/benchmark/etc/zinit/sshd.yaml
+++ b/tfgrid3/benchmark/etc/zinit/sshd.yaml
@@ -1,0 +1,1 @@
+exec: /usr/sbin/sshd -D -e

--- a/tfgrid3/benchmark/etc/zinit/write-env.yaml
+++ b/tfgrid3/benchmark/etc/zinit/write-env.yaml
@@ -1,0 +1,2 @@
+exec: sh -c 'env > /root/.env'
+oneshot: true


### PR DESCRIPTION
## Description

Add benchmark flist with instruction on how to use. This is needed for guardian healthchecker [story](https://github.com/threefoldtech/home/issues/1535).