### PR TITLE
ZOS Boot Generator Flist (Grid Stack Suite Part 2 of 3)

### DIFF
--- a/tfgrid3/zos_boot_generator/Dockerfile
+++ b/tfgrid3/zos_boot_generator/Dockerfile
@@ -5,7 +5,8 @@ RUN dpkg --add-architecture i386
 RUN apt update && \
   echo "2" | apt install -y python3-flask && \
   apt install -y mtools syslinux isolinux libc6-dev-i386 ufw \
-  libc6-dbg:i386 git wget genisoimage liblzma-dev build-essential sqlite3
+  libc6-dbg:i386 git wget genisoimage liblzma-dev build-essential sqlite3 \
+  openssh-server curl sudo inotify-tools iproute2
 
 RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
   chmod +x /sbin/zinit

--- a/tfgrid3/zos_boot_generator/Dockerfile
+++ b/tfgrid3/zos_boot_generator/Dockerfile
@@ -14,6 +14,12 @@ RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download
 RUN wget -O /sbin/caddy 'https://caddyserver.com/api/download?os=linux&arch=amd64&p=github.com%2Fcaddyserver%2Freplace-response&idempotency=43631173212363' && \
   chmod +x /sbin/caddy
 
+RUN mkdir -p /code && \
+  cd /code && \
+  git clone https://github.com/threefoldtech/0-bootstrap && \
+  cd 0-bootstrap && \
+  bash setup/template.sh
+
 COPY ./scripts/ /scripts/
 COPY ./zinit/ /etc/zinit/
 RUN chmod +x /scripts/*.sh

--- a/tfgrid3/zos_boot_generator/Dockerfile
+++ b/tfgrid3/zos_boot_generator/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:22.04
+
+RUN dpkg --add-architecture i386
+
+RUN apt update && \
+  echo "2" | apt install -y python3-flask && \
+  apt install -y mtools syslinux isolinux libc6-dev-i386 ufw \
+  libc6-dbg:i386 git wget genisoimage liblzma-dev build-essential sqlite3
+
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
+  chmod +x /sbin/zinit
+
+RUN wget -O /sbin/caddy 'https://caddyserver.com/api/download?os=linux&arch=amd64&p=github.com%2Fcaddyserver%2Freplace-response&idempotency=43631173212363' && \
+  chmod +x /sbin/caddy
+
+COPY ./scripts/ /scripts/
+COPY ./zinit/ /etc/zinit/
+RUN chmod +x /scripts/*.sh
+
+ENTRYPOINT ["/sbin/zinit", "init"]

--- a/tfgrid3/zos_boot_generator/README.md
+++ b/tfgrid3/zos_boot_generator/README.md
@@ -1,0 +1,130 @@
+<h1> Z-OS Boot Generator </h1>
+
+<h2> Table of Contents </h2>
+
+- [Introduction](#introduction)
+- [Create the Docker Image](#create-the-docker-image)
+- [Convert the Docker Image to Zero-OS FList](#convert-the-docker-image-to-zero-os-flist)
+- [TFGrid Deployment](#tfgrid-deployment)
+  - [Dashboard Steps](#dashboard-steps)
+  - [Set the DNS Record for Your Domain](#set-the-dns-record-for-your-domain)
+- [Access the Z-OS Bootstrap Generator](#access-the-z-os-bootstrap-generator)
+- [Conclusion](#conclusion)
+
+***
+
+## Introduction
+
+This Z-OS Boot Generator FList can be deployed on a micro VM on the ThreeFold Grid, either via the TF Dashboard, or Terraform. This FList uses `Ubuntu 22.04` and also includes the preinstalled `openssh-server` package. Docker is installed directly from [www.get.docker.com](https://get.docker.com/). This FList  Z-OS Boot Generator is installed based on the latest Z-OS Boot Generator release from the Docker Hub.
+
+To simply deploy the available FList on the ThreeFold Dashboard, skip to [this section](#dashboard-steps).
+
+<!--
+Note that the official FList for Z-OS Boot Generator is the following:
+
+```
+https://hub.grid.tf/tf-official-apps/threefoldtech-zos_boot_generator-latest.flist
+```
+-->
+
+***
+
+## Create the Docker Image
+
+To create the the Z-OS Boot Generator image, clone this repository, then build and push the image to the Docker Hub.
+
+* Clone the repository:
+  * ```
+    git clone https://github.com/threefoldtech/tf-images
+    ```
+  * ```
+    cd tf-images/tfgrid3/zos_boot_generator
+    ```
+* Build the image:
+  * ```
+    docker build -t <docker_username>/zos_boot_generator .
+    ```
+* Push the image to the Docker Hub:
+  * ```
+    docker push <your_username>/zos_boot_generator
+    ```
+ 
+***
+
+## Convert the Docker Image to Zero-OS FList
+
+The easiest way to convert the docker image to an FList is by using the [Docker Hub Converter Tool](https://hub.grid.tf/docker-convert). This can be done once you've built and pushed the docker image on the [Docker Hub](https://hub.docker.com/).
+
+> Note: A docker image has already been converted to an FList (see below).
+
+* Go to the [ThreeFold Hub](https://hub.grid.tf/).
+* Sign in with the ThreeFold Connect app.
+* Go to the [Docker Hub Converter](https://hub.grid.tf/docker-convert) section.
+* Next to `Docker Image Name`, add the docker image repository and name, see the example below:
+  * Template:
+    * `<docker_username>/docker_image_name:tagname`
+* Click `Convert the docker image`.
+* Once the conversion is done, the FList is available as a public link on the ThreeFold Hub.
+* To get the FList URL, go to the [TF Hub main page](https://hub.grid.tf/), scroll down to your 3Bot ID and click on it.
+* Under `Name`, you will see all your available FLists.
+* Right-click on the FList you want and select `Copy Clean Link`. This URL will be used when deploying on the ThreeFold Dashboard. We show below the template and an example of what the FList URL looks like.
+  * Template:
+    * ```
+      https://hub.grid.tf/<3BOT_name.3bot>/<docker_username>-<docker_image_name>-<tagname>.flist
+      ```
+
+***
+## TFGrid Deployment
+
+The easiest way to deploy a micro VM using the Z-OS Boot Generator FList is to head to to the [ThreeFold Dashboard](https://dashboard.grid.tf) and deploy a [Micro Virtual Machine](https://dashboard.grid.tf/#/deploy/virtual-machines/micro-virtual-machine/) by providing the FList URL. Make sure to select `IPv4`.
+
+Make sure to provide the correct entrypoint (`/sbin/zinit init`). Note that the entrypoint should already be set by default when you open the micro VM page. 
+
+You could also use Terraform instead of the Dashboard to deploy the Z-OS Boot Generator Micro VM. Read more on this [here](https://github.com/threefoldtech/terraform-provider-grid).
+
+### Dashboard Steps
+
+* Go to the [ThreeFold Dashboard](https://dashboard.grid.tf)
+* Log into your TF wallet
+* Go to the [Micro VM](https://dashboard.grid.tf/#/deploy/virtual-machines/micro-virtual-machine/) page
+* In the section `Config`, 
+  * Choose a name for your VM under `Name`.
+  * Under `VM Image`, select `Other`.
+    * Enter the Zero-OS Boot Generator FList under `Flist`:
+      * Template:
+        * ```
+          https://hub.grid.tf/<3BOT_name.3bot>/<docker_username>-<docker_image_name>-<tagname>.flist
+          ```
+      * Example:
+        * ```
+          https://hub.grid.tf/tf-official-apps/threefoldtech-zos_boot_generator-latest.flist
+          ```
+  * Under `Entry Point`, the following should be set by default: `/sbin/zinit init`
+  * `Select instance capacity` can be set at `Small` (1vcore, 2GB memory, 25GB SSd)
+  * Make sure that `Public IPv4` is enabled (required).
+* In the tab `Environment Variables`. Click on the `plus` button then add `DOMAIN` for `Name` and your domain (e.g. `example.com`) for `Value`.
+* Click `Deploy`.
+
+### Set the DNS Record for Your Domain
+
+* Go to your domain name registrar (e.g. Namecheap)
+  * In the section Advanced DNS, add a DNS A Record to your domain and link it to the VM IPv4 Address
+    * Type: A Record
+    * Host: @
+    * Value: VM IPv4 Address
+    * TTL: Automatic
+  * It might take up to 30 minutes to set the DNS properly.
+  * To check if the A record has been registered, you can use a common DNS checker:
+    * ```
+      https://dnschecker.org/#A/<domain-name>
+      ```
+
+## Access the Z-OS Bootstrap Generator
+
+You can now access the Z-OS Bootstrap Generator at your domain, e.g. `https://example.com`.
+
+## Conclusion
+
+We've seen the overall process of creating a new FList to deploy a Z-OS Boot Generator workload on a Micro VM on the ThreeFold Dashboard.
+
+If you have any questions or feedback, please let us know by either writing a post on the [ThreeFold Forum](https://forum.threefold.io/), or by chatting with us on the [TF Grid Tester Community](https://t.me/threefoldtesting) Telegram channel.

--- a/tfgrid3/zos_boot_generator/README.md
+++ b/tfgrid3/zos_boot_generator/README.md
@@ -15,7 +15,7 @@
 
 ## Introduction
 
-This Z-OS Boot Generator FList can be deployed on a micro VM on the ThreeFold Grid, either via the TF Dashboard, or Terraform. This FList uses `Ubuntu 22.04` and also includes the preinstalled `openssh-server` package. Docker is installed directly from [www.get.docker.com](https://get.docker.com/). This FList  Z-OS Boot Generator is installed based on the latest Z-OS Boot Generator release from the Docker Hub.
+This Z-OS Boot Generator FList can be deployed on a micro VM on the ThreeFold Grid, either via the TF Dashboard, or Terraform. This FList uses `Ubuntu 22.04` and also includes the preinstalled `openssh-server` package. This FList  Z-OS Boot Generator is installed based on the latest Z-OS Boot Generator release from the Docker Hub.
 
 To simply deploy the available FList on the ThreeFold Dashboard, skip to [this section](#dashboard-steps).
 

--- a/tfgrid3/zos_boot_generator/scripts/caddy.sh
+++ b/tfgrid3/zos_boot_generator/scripts/caddy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-caddy reverse-proxy -r --from ${DOMAIN} --to :5555
+caddy reverse-proxy -r --from $DOMAIN --to :5555

--- a/tfgrid3/zos_boot_generator/scripts/caddy.sh
+++ b/tfgrid3/zos_boot_generator/scripts/caddy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-caddy reverse-proxy -r --from $DOMAIN --to :5555
+caddy reverse-proxy -r --from ${DOMAIN} --to :5555

--- a/tfgrid3/zos_boot_generator/scripts/caddy.sh
+++ b/tfgrid3/zos_boot_generator/scripts/caddy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+caddy reverse-proxy -r --from ${DOMAIN} --to :5555

--- a/tfgrid3/zos_boot_generator/scripts/python.sh
+++ b/tfgrid3/zos_boot_generator/scripts/python.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd ./program/0-bootstrap
+
+python3 bootstrap.py

--- a/tfgrid3/zos_boot_generator/scripts/python.sh
+++ b/tfgrid3/zos_boot_generator/scripts/python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-cd ./program/0-bootstrap
+cd /code/0-bootstrap
 
 python3 bootstrap.py

--- a/tfgrid3/zos_boot_generator/scripts/sshd_init.sh
+++ b/tfgrid3/zos_boot_generator/scripts/sshd_init.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p ~/.ssh
+mkdir -p /var/run/sshd
+chmod 600 ~/.ssh
+chmod 600 /etc/ssh/*
+echo $SSH_KEY >> ~/.ssh/authorized_keys

--- a/tfgrid3/zos_boot_generator/scripts/ufw_init.sh
+++ b/tfgrid3/zos_boot_generator/scripts/ufw_init.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-ufw default deny incoming
-ufw default allow outgoing
 ufw allow 80
 ufw allow 443
 ufw allow 22
-ufw limit ssh

--- a/tfgrid3/zos_boot_generator/scripts/ufw_init.sh
+++ b/tfgrid3/zos_boot_generator/scripts/ufw_init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 80
+ufw allow 443
+ufw allow 22
+ufw limit ssh

--- a/tfgrid3/zos_boot_generator/scripts/zos_boot_generator.sh
+++ b/tfgrid3/zos_boot_generator/scripts/zos_boot_generator.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+mkdir -p ./program
+
+cd ./program
+
 git clone https://github.com/threefoldtech/0-bootstrap
 cd 0-bootstrap
 
@@ -13,5 +17,3 @@ sed -i "s/http:\/\/default\.tld/https:\/\/$domain_name\.$domain_tld/g" config.py
 cat db/schema.sql | sqlite3 db/bootstrap.sqlite3
 
 bash setup/template.sh
-
-python3 bootstrap.py

--- a/tfgrid3/zos_boot_generator/scripts/zos_boot_generator.sh
+++ b/tfgrid3/zos_boot_generator/scripts/zos_boot_generator.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+git clone https://github.com/threefoldtech/0-bootstrap
+cd 0-bootstrap
+
+cp config.py.sample config.py
+
+domain_name=$(echo $DOMAIN | cut -d. -f1)
+domain_tld=$(echo $DOMAIN | cut -d. -f2)
+
+sed -i "s/http:\/\/default\.tld/https:\/\/$domain_name\.$domain_tld/g" config.py
+
+cat db/schema.sql | sqlite3 db/bootstrap.sqlite3
+
+bash setup/template.sh
+
+python3 bootstrap.py

--- a/tfgrid3/zos_boot_generator/scripts/zos_boot_generator.sh
+++ b/tfgrid3/zos_boot_generator/scripts/zos_boot_generator.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-mkdir -p ./program
-
-cd ./program
-
-git clone https://github.com/threefoldtech/0-bootstrap
-cd 0-bootstrap
+cd /code/0-bootstrap
 
 cp config.py.sample config.py
 
@@ -15,5 +10,3 @@ domain_tld=$(echo $DOMAIN | cut -d. -f2)
 sed -i "s/http:\/\/default\.tld/https:\/\/$domain_name\.$domain_tld/g" config.py
 
 cat db/schema.sql | sqlite3 db/bootstrap.sqlite3
-
-bash setup/template.sh

--- a/tfgrid3/zos_boot_generator/zinit/caddy.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/caddy.yaml
@@ -1,0 +1,2 @@
+exec: /scripts/caddy.sh
+oneshot: true

--- a/tfgrid3/zos_boot_generator/zinit/caddy.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/caddy.yaml
@@ -1,2 +1,1 @@
 exec: /scripts/caddy.sh
-oneshot: true

--- a/tfgrid3/zos_boot_generator/zinit/python.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/python.yaml
@@ -1,0 +1,3 @@
+exec: /scripts/python.sh
+after:
+  - zos_boot_generator.sh

--- a/tfgrid3/zos_boot_generator/zinit/python.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/python.yaml
@@ -1,3 +1,3 @@
 exec: /scripts/python.sh
 after:
-  - zos_boot_generator.sh
+  - zos_boot_generator

--- a/tfgrid3/zos_boot_generator/zinit/ssh-init.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/ssh-init.yaml
@@ -1,0 +1,2 @@
+exec: /scripts/sshd_init.sh
+oneshot: true

--- a/tfgrid3/zos_boot_generator/zinit/sshd.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/sshd.yaml
@@ -1,0 +1,3 @@
+exec: bash -c "/usr/sbin/sshd -D"
+after:
+  - ssh-init

--- a/tfgrid3/zos_boot_generator/zinit/ufw-init.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/ufw-init.yaml
@@ -1,0 +1,3 @@
+exec: /scripts/ufw_init.sh
+oneshot: true
+

--- a/tfgrid3/zos_boot_generator/zinit/ufw.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/ufw.yaml
@@ -1,0 +1,4 @@
+exec: ufw --force enable
+oneshot: true
+after:
+  - ufw-init

--- a/tfgrid3/zos_boot_generator/zinit/zos_boot_generator.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/zos_boot_generator.yaml
@@ -1,0 +1,3 @@
+exec: /scripts/zos_boot_generator.sh
+after:
+  - sshd

--- a/tfgrid3/zos_boot_generator/zinit/zos_boot_generator.yaml
+++ b/tfgrid3/zos_boot_generator/zinit/zos_boot_generator.yaml
@@ -1,3 +1,4 @@
 exec: /scripts/zos_boot_generator.sh
+oneshot: true
 after:
   - sshd


### PR DESCRIPTION
# Work Done

- Flist to deploy automatically the zero-os bootstrap generator
- Created a basic ipv4 micro vm flist with 1 additional env var (DOMAIN: example.com)
- README contains all steps to build the image from Docker to Flist hub, to dashboard deployment of micro VM

# Future Work

- Add gateway, domain, Caddyfile features as done in Nextcloud flist
- Turn this flist (base version of this PR) into Dashboard app
- Add images
- Cover all types of domain
- This serves as a basic proof-of-concept of the bootstrap part of the tfgrid full stack suite

# UX

- User can deploy a micro VM IPV4 network with the Flist, set the DOMAIN example.com, set a DNS A record and it works 100%

# Images

- Screenshot final output
![image](https://github.com/user-attachments/assets/47a38434-904c-4619-a453-d66d579d7534)

# References

- Work done for the TFGrid Full Stack Suite project: https://github.com/threefoldtech/home/issues/1563
- Collaboration and advice: @scottyeager, @maxux and @coesensbert 