### PR TITLE
update k3s version to 1.31.0 with 24.04  as base image

### DIFF
--- a/tfgrid3/k3s/Dockerfile
+++ b/tfgrid3/k3s/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get -qy update && \
     apt-get -qy install wget ssh iproute2 ntp && \
-    wget --progress=bar:force:noscroll -O /sbin/k3s https://github.com/k3s-io/k3s/releases/download/v1.30.0+k3s1/k3s && \
+    wget --progress=bar:force:noscroll -O /sbin/k3s https://github.com/k3s-io/k3s/releases/download/v1.31.0+k3s1/k3s && \
     chmod +x /sbin/k3s && \
-    wget --progress=bar:force:noscroll -O /sbin/kubectl https://dl.k8s.io/release/v1.30.0/bin/linux/amd64/kubectl && \
+    wget --progress=bar:force:noscroll -O /sbin/kubectl https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl && \
     chmod +x /sbin/kubectl && \
     wget --progress=bar:force:noscroll -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit && \
     chmod +x /sbin/zinit && \


### PR DESCRIPTION
- update k3s version to the latest version released 1.31.0 
- update the base image used to build using ubuntu 24.04 instead of 20.04