### PR TITLE
fix mattermost image smtp ,ssh and mail notification

### DIFF
--- a/tfgrid3/mattermost_aio/Dockerfile
+++ b/tfgrid3/mattermost_aio/Dockerfile
@@ -15,7 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y curl jq sudo libffi-dev netcat-openbsd tzdata libcap2-bin postgresql postgresql postgresql-contrib openssh-server ufw\
     && rm -rf /tmp/* \
-    && wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit \
+    && wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit \
     && chmod +x /sbin/zinit \
     && mkdir -p /etc/zinit
 COPY scripts /etc/zinit

--- a/tfgrid3/mattermost_aio/scripts/entrypoint.sh
+++ b/tfgrid3/mattermost_aio/scripts/entrypoint.sh
@@ -13,6 +13,9 @@ cat <<EOF > /tmp/init_postgres.sql
 create database mattermost;
 create user $MM_USERNAME password '$DB_PASSWORD';
 grant all privileges on database mattermost to $MM_USERNAME;
+GRANT ALL ON DATABASE mattermost TO $MM_USERNAME;
+ALTER DATABASE mattermost OWNER TO $MM_USERNAME;
+GRANT USAGE, CREATE ON SCHEMA PUBLIC TO $MM_USERNAME;
 \c mattermost
 CREATE EXTENSION pg_trgm;
 CREATE EXTENSION unaccent;
@@ -58,12 +61,14 @@ if [ "$1" = 'mattermost' ]; then
     jq '.FileSettings.Directory = "/mattermost/data/"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.FileSettings.EnablePublicLink = true' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.FileSettings.PublicLinkSalt = "'$(generate_salt)'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
-    jq '.EmailSettings.SendEmailNotifications = false' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.EmailSettings.SendEmailNotifications = true' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.EmailSettings.FeedbackEmail = ""' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
-    jq '.EmailSettings.SMTPUsername = "'$SMTPUSERNAME'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
-    jq '.EmailSettings.SMTPPassword = "'$SMTPPASSWORD'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
-    jq '.EmailSettings.SMTPServer = "'$SMTPSERVER'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
-    jq '.EmailSettings.SMTPPort = "'$SMTPPORT'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.EmailSettings.SMTPUsername = "'$SMTPUsername'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.EmailSettings.SMTPPassword = "'$SMTPPassword'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.EmailSettings.SMTPServer = "'$SMTPServer'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.EmailSettings.SMTPPort = "'$SMTPPort'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.EmailSettings.ConnectionSecurity = "STARTTLS"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.EmailSettings.EnableSMTPAuth = true' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.EmailSettings.InviteSalt = "'$(generate_salt)'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.EmailSettings.PasswordResetSalt = "'$(generate_salt)'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.EmailSettings.EnableSignUpWithEmail = false' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG

--- a/tfgrid3/mattermost_aio/scripts/postgresql.yaml
+++ b/tfgrid3/mattermost_aio/scripts/postgresql.yaml
@@ -4,6 +4,6 @@ exec: |
     chmod 0640 /etc/ssl/private/ssl-cert-snakeoil.key
     service postgresql start 
     service postgresql stop
-    runuser -u postgres -- /usr/lib/postgresql/12/bin/postgres -D /var/lib/postgresql/12/main -c config_file=/etc/postgresql/12/main/postgresql.conf
+    runuser -u postgres -- /usr/lib/postgresql/16/bin/postgres -D /var/lib/postgresql/16/main -c config_file=/etc/postgresql/16/main/postgresql.conf
   '
 test: pg_isready -d mattermost

--- a/tfgrid3/mattermost_aio/scripts/sshd.yaml
+++ b/tfgrid3/mattermost_aio/scripts/sshd.yaml
@@ -1,1 +1,1 @@
-exec: bash -c "/usr/sbin/sshd -D"
+exec: /usr/sbin/sshd -D

--- a/tfgrid3/mattermost_aio/scripts/sshkey.yaml
+++ b/tfgrid3/mattermost_aio/scripts/sshkey.yaml
@@ -7,7 +7,6 @@ exec: |
       
       chmod 700 /root/.ssh
       chmod 600 /root/.ssh/authorized_keys
-      echo "$SSH_KEY" >> /root/.ssh/authorized_keys
     fi
   '
 oneshot: true


### PR DESCRIPTION
- fixing SMTP as it's credentials wasn't passed to config due to wrong env vars naming , so SMTP wasn't working .
- fixing ssh key copying command which was still there , and it's removed now .
- fixing email notification option wasn't enabled and was throwing error in zinit log .
- fixing postgres error when build new image as it was using postgresql v12 and the new ubuntu image use postgres 16 . 