### PR TITLE
Update casper image

### DIFF
--- a/tfgrid3/casper/Dockerfile
+++ b/tfgrid3/casper/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="abdul@incubaid.com"
 WORKDIR /opt
@@ -48,6 +48,9 @@ RUN set -ex; \
 RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit \
     && chmod +x /sbin/zinit \
     && mkdir -p /etc/zinit
+
+# Fix SSH - create sshd directory
+RUN mkdir -p /run/sshd && chmod 0755 /run/sshd
 
 COPY scripts /etc/zinit
 

--- a/tfgrid3/casper/README.md
+++ b/tfgrid3/casper/README.md
@@ -1,16 +1,17 @@
 # Casper
 
-* Protocol version "1.1.0" 
-* Image for flist = ```docker pull arrajput/casper-flist:1.0```
-* flist = ```https://hub.grid.tf/arehman/arrajput-casper-flist-1.0.flist```
+* Protocol version "2.0.4" 
+* Base Image: Ubuntu 22.04 LTS
+* Image for flist = ```docker build -t casper:2.0.4 .```
+* flist = ```https://hub.grid.tf/tf-official-apps/casperlabs-latest.flist```
 
 This image will start a Casper full node 
 
 ### Hardware requirements
 
   * 4 Cores
-  * 16 GB Ram
-  * 1 TB disk
+  * 32 GB Ram
+  * 500 TB disk
 
 ### How to build from the Dockerfile ?
 

--- a/tfgrid3/casper/scripts/install_casper
+++ b/tfgrid3/casper/scripts/install_casper
@@ -1,43 +1,15 @@
+#!/usr/bin/env bash
 set -ex
 
 ## Set version and network
-CASPER_VERSION=1_0_0
+CASPER_VERSION=2_0_4
 CASPER_NETWORK=casper
 
-### Install Casper node
-echo "deb https://repo.casper.network/releases" bionic main | sudo tee -a /etc/apt/sources.list.d/casper.list
-curl -O https://repo.casper.network/casper-repo-pubkey.asc
-sudo apt-key add casper-repo-pubkey.asc
+### Add Casper repository and install packages
+echo "deb [arch=amd64] https://repo.casper.network/releases $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/casper.list
+curl -fsSL https://repo.casper.network/casper-repo-pubkey.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/casper.gpg
 sudo apt update
-sudo apt install casper-node-launcher casper-client -y
+sudo apt install -y casper-node-launcher casper-client
 
-### Install pre-requisites for building smart contracts
-cd ~
-wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'   
-sudo apt update
-
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-. /$HOME/.cargo/env
-
-
-BRANCH="1.0.20" \
-    && git clone --branch ${BRANCH} https://github.com/WebAssembly/wabt.git "wabt-${BRANCH}" \
-    && cd "wabt-${BRANCH}" \
-    && git submodule update --init \
-    && cd - \
-    && cmake -S "wabt-${BRANCH}" -B "wabt-${BRANCH}/build" \
-    && cmake --build "wabt-${BRANCH}/build" --parallel 8 \
-    && sudo cmake --install "wabt-${BRANCH}/build" --prefix /usr --strip -v \
-    && rm -rf "wabt-${BRANCH}"
-
-### Build smart contracts
-cd ~
-
-git clone https://github.com/casper-network/casper-node.git
-cd casper-node/
-
-git checkout release-1.4.4
-
-make setup-rs
-make build-client-contracts -j
+### Create casper user if it doesn't exist
+id -u casper &>/dev/null || sudo useradd -m -d /etc/casper casper

--- a/tfgrid3/casper/scripts/start_casper
+++ b/tfgrid3/casper/scripts/start_casper
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ex
-CASPER_VERSION=1_5_8
+CASPER_VERSION=2_0_4
 CASPER_NETWORK=casper
 
 # Frontend
@@ -15,10 +15,11 @@ fi
 /etc/init.d/cron start
 chmod 777 /tmp/*
 
-### Generate node keys
-rm /etc/casper/validator_keys/*
+### Generate node keys (only if they don't exist)
 cd /etc/casper/validator_keys
-sudo -u casper casper-client keygen .
+if [ ! -f secret_key.pem ]; then
+    sudo -u casper casper-client keygen .
+fi
 
 
 ### Set up configuration
@@ -42,12 +43,14 @@ done
 # Check knownvalidator ip was found and set
 if [ -z ${KNOWN_VALIDATOR_IP} ]; then exit 1; fi
 
-# Get trusted_hash into config.toml
-TRUSTED_HASH=$(casper-client get-block --node-address http://$KNOWN_VALIDATOR_IP:7777 | jq -r .result.block.hash | tr -d '\n')
-if [ "$TRUSTED_HASH" != "null" ]; then sudo -u casper sed -i "7c\trusted_hash = '$TRUSTED_HASH'" /etc/casper/$CASPER_VERSION/config.toml; fi
+# Get trusted_hash into config.toml (only if valid)
+TRUSTED_HASH=$(casper-client get-block --node-address http://$KNOWN_VALIDATOR_IP:7777 -b 4494833 | jq -r .result.block.hash | tr -d '\n')
+if [ -n "$TRUSTED_HASH" ] && [ "$TRUSTED_HASH" != "null" ]; then 
+    sudo -u casper sed -i "/trusted_hash =/c\trusted_hash = '$TRUSTED_HASH'" /etc/casper/$CASPER_VERSION/config.toml
+fi
 
 
 
 ### Start the node
 sudo /etc/casper/node_util.py rotate_logs
-exec casper-node-launcher -f 1.5.8
+exec casper-node-launcher -f 2.0.4

--- a/tfgrid3/casper/scripts/start_casper
+++ b/tfgrid3/casper/scripts/start_casper
@@ -49,8 +49,6 @@ if [ -n "$TRUSTED_HASH" ] && [ "$TRUSTED_HASH" != "null" ]; then
     sudo -u casper sed -i "/trusted_hash =/c\trusted_hash = '$TRUSTED_HASH'" /etc/casper/$CASPER_VERSION/config.toml
 fi
 
-
-
 ### Start the node
 sudo /etc/casper/node_util.py rotate_logs
-exec casper-node-launcher -f 2.0.4
+exec casper-node-launcher > /var/www/html/node.log 2>&1


### PR DESCRIPTION
- Update Dockerfile base image from Ubuntu 18.04 to 22.04
- Fix install_casper script to use modern Casper repository
- Update start_casper script with key fixes:
  * Check for existing validator keys before generating
  * Validate trusted_hash before setting to prevent empty hash errors
  * Use Casper node version 2.0.4 for network compatibility
- Update README with new version information
