### PR TITLE
Revert zinit/rfs URL rename

### DIFF
--- a/tfgrid3/algorand/Dockerfile
+++ b/tfgrid3/algorand/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && \
     apt -y install wget curl vim net-tools iputils-ping openssh-server
 
 # Download and install latest zinit
-RUN curl -s https://api.github.com/repos/threefoldtech/zos_zinit/releases/latest | \
+RUN curl -s https://api.github.com/repos/threefoldtech/zinit/releases/latest | \
     grep "browser_download_url" | \
     cut -d '"' -f 4 | \
     wget -qi - -O /sbin/zinit

--- a/tfgrid3/arch_mycelium/Dockerfile
+++ b/tfgrid3/arch_mycelium/Dockerfile
@@ -5,7 +5,7 @@ RUN pacman -Syu --noconfirm && \
     pacman -S --noconfirm wget curl git openssh ufw
 
 # Download and install latest zinit
-RUN curl -s https://api.github.com/repos/threefoldtech/zos_zinit/releases/latest | \
+RUN curl -s https://api.github.com/repos/threefoldtech/zinit/releases/latest | \
     grep "browser_download_url" | \
     cut -d '"' -f 4 | \
     wget -qi - -O /sbin/zinit

--- a/tfgrid3/aydo/Dockerfile
+++ b/tfgrid3/aydo/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=aydo-builder /aydo/openapi /usr/share/sftpgo/openapi
 
 RUN apt update && apt install -y openssh-server dnsutils
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.11/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.11/zinit && \
     chmod +x /sbin/zinit
 
 ENTRYPOINT ["zinit", "init"]

--- a/tfgrid3/benchmark/build.sh
+++ b/tfgrid3/benchmark/build.sh
@@ -27,7 +27,7 @@ mv cpubench rootfs/sbin/
 cp benchmark rootfs/etc/periodic/15min/
 
 # setup zinit
-wget https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit
+wget https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit
 chmod +x zinit
 mv zinit rootfs/sbin/zinit
 

--- a/tfgrid3/btcnode/Dockerfile
+++ b/tfgrid3/btcnode/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get install -y wget software-properties-common curl openssh-server ufw
 
 # Download and install latest zinit
-RUN curl -s https://api.github.com/repos/threefoldtech/zos_zinit/releases/latest | \
+RUN curl -s https://api.github.com/repos/threefoldtech/zinit/releases/latest | \
     grep "browser_download_url" | \
     cut -d '"' -f 4 | \
     wget -qi - -O /sbin/zinit

--- a/tfgrid3/casper/Dockerfile
+++ b/tfgrid3/casper/Dockerfile
@@ -44,7 +44,7 @@ RUN set -ex; \
         ;
 
 # Install zinit
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit \
     && chmod +x /sbin/zinit \
     && mkdir -p /etc/zinit
 

--- a/tfgrid3/dagu/Dockerfile
+++ b/tfgrid3/dagu/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH="/root/hero/bin:${PATH}"
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 
 # Copy entrypoint script
-RUN  curl -sSL "https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit" -o /sbin/zinit &&\
+RUN  curl -sSL "https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit" -o /sbin/zinit &&\
     chmod +x /sbin/zinit
 RUN echo PATH=${PATH} >> /root/.bashrc
 

--- a/tfgrid3/debian/Dockerfile
+++ b/tfgrid3/debian/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:12
 RUN apt update && \
   apt -y install wget openssh-server
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
   chmod +x /sbin/zinit
 
 COPY zinit /etc/zinit

--- a/tfgrid3/docker-ssh/Dockerfile
+++ b/tfgrid3/docker-ssh/Dockerfile
@@ -20,7 +20,7 @@ RUN apt update
 
 RUN apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.12/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.12/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit

--- a/tfgrid3/forum-3/Dockerfile
+++ b/tfgrid3/forum-3/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
     apt -y install wget curl vim net-tools iputils-ping openssh-server docker.io git nginx
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit

--- a/tfgrid3/funkwhale/Dockerfile
+++ b/tfgrid3/funkwhale/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download and install the latest Zinit
-RUN curl -s https://api.github.com/repos/threefoldtech/zos_zinit/releases/latest | \
+RUN curl -s https://api.github.com/repos/threefoldtech/zinit/releases/latest | \
     grep "browser_download_url" | \
     cut -d '"' -f 4 | \
     wget -qi - -O /sbin/zinit && \

--- a/tfgrid3/gitea/Dockerfile
+++ b/tfgrid3/gitea/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && \
   apt -y install wget openssh-server sudo sqlite3
 
 # Install zinit
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
   chmod +x /sbin/zinit
 
 # Copy zinit configuration and startup script

--- a/tfgrid3/gitea_mycelium/Dockerfile
+++ b/tfgrid3/gitea_mycelium/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && \
     apt install -y --no-install-recommends wget ca-certificates curl gnupg openssh-server ufw
 
 # Download and install latest zinit
-RUN curl -s https://api.github.com/repos/threefoldtech/zos_zinit/releases/latest | \
+RUN curl -s https://api.github.com/repos/threefoldtech/zinit/releases/latest | \
     grep "browser_download_url" | \
     cut -d '"' -f 4 | \
     wget -qi - -O /sbin/zinit

--- a/tfgrid3/holochain/Dockerfile
+++ b/tfgrid3/holochain/Dockerfile
@@ -21,7 +21,7 @@ RUN nix-env -iA nixpkgs.mc
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 
 # Copy entrypoint script
-RUN  curl -sSL "https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit" -o /sbin/zinit &&\
+RUN  curl -sSL "https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit" -o /sbin/zinit &&\
     chmod +x /sbin/zinit
 RUN echo PATH=${PATH} >> /root/.bashrc
 

--- a/tfgrid3/ipfs_cluster/Dockerfile
+++ b/tfgrid3/ipfs_cluster/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /build
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get -qy update && \
     apt-get -qy install wget openssh-server && \
-    wget -nv -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.9/zinit && \
+    wget -nv -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.9/zinit && \
     wget -nv https://dist.ipfs.tech/kubo/v0.16.0/kubo_v0.16.0_linux-amd64.tar.gz \
     https://dist.ipfs.tech/ipfs-cluster-service/v1.0.4/ipfs-cluster-service_v1.0.4_linux-amd64.tar.gz \
     https://dist.ipfs.io/ipfs-cluster-ctl/v1.0.4/ipfs-cluster-ctl_v1.0.4_linux-amd64.tar.gz && \

--- a/tfgrid3/jenkins/Dockerfile
+++ b/tfgrid3/jenkins/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.je
 
 RUN apt update && apt -y install jenkins default-jre
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && chmod +x /sbin/zinit
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && chmod +x /sbin/zinit
 
 COPY rootfs /
 

--- a/tfgrid3/jitsi/Dockerfile
+++ b/tfgrid3/jitsi/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
 apt -y install wget openssh-server
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit && \
 chmod +x /sbin/zinit
 
 RUN apt upgrade -y

--- a/tfgrid3/k3s/Dockerfile
+++ b/tfgrid3/k3s/Dockerfile
@@ -5,7 +5,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -qy update && \
     chmod +x /sbin/k3s && \
     wget --progress=bar:force:noscroll -O /sbin/kubectl https://dl.k8s.io/release/v1.33.1/bin/linux/amd64/kubectl && \
     chmod +x /sbin/kubectl && \
-    wget --progress=bar:force:noscroll -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit && \
+    wget --progress=bar:force:noscroll -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit && \
     chmod +x /sbin/zinit && \
     apt-get -qy remove wget && apt-get -qy autoremove && \
     rm -rf /var/lib/apt/lists/* && rm -rf /build/* && unset DEBIAN_FRONTEND

--- a/tfgrid3/mariadb/Dockerfile
+++ b/tfgrid3/mariadb/Dockerfile
@@ -11,7 +11,7 @@ RUN wget https://github.com/prometheus/mysqld_exporter/releases/download/v0.15.1
     tar xvfz mysqld_exporter-0.15.1.linux-amd64.tar.gz && \
     mv mysqld_exporter-0.15.1.linux-amd64/mysqld_exporter /usr/local/bin
     
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && chmod +x /sbin/zinit
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && chmod +x /sbin/zinit
 COPY rootfs /
 
 EXPOSE 9500 9501

--- a/tfgrid3/mariadb_aio/Dockerfile
+++ b/tfgrid3/mariadb_aio/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y docker-ce
 
 COPY . .
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
     chmod +x /sbin/zinit
 
 

--- a/tfgrid3/massdep_nginx/Dockerfile
+++ b/tfgrid3/massdep_nginx/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 RUN apt update && \
   apt -y install wget openssh-server nginx
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit && \
   chmod +x /sbin/zinit
 
 COPY zinit /etc/zinit

--- a/tfgrid3/mastodon/Dockerfile
+++ b/tfgrid3/mastodon/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     wget -qO- https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null && \
     # Zinit
-    wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.10/zinit && \
+    wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.10/zinit && \
     chmod +x /sbin/zinit && \
     # Webmin
     wget -q http://www.webmin.com/jcameron-key.asc -O- | apt-key add - && \

--- a/tfgrid3/mattermost_aio/Dockerfile
+++ b/tfgrid3/mattermost_aio/Dockerfile
@@ -15,7 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y curl jq sudo libffi-dev netcat-openbsd tzdata libcap2-bin postgresql postgresql postgresql-contrib openssh-server ufw\
     && rm -rf /tmp/* \
-    && wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit \
+    && wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit \
     && chmod +x /sbin/zinit \
     && mkdir -p /etc/zinit
 COPY scripts /etc/zinit

--- a/tfgrid3/monitor/Dockerfile
+++ b/tfgrid3/monitor/Dockerfile
@@ -16,7 +16,7 @@ RUN apt -y install adduser libfontconfig1 musl && \
     wget https://dl.grafana.com/enterprise/release/grafana-enterprise_11.1.3_amd64.deb && \
     dpkg -i grafana-enterprise_11.1.3_amd64.deb
     
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
     chmod +x /sbin/zinit
 
 COPY rootfs .

--- a/tfgrid3/nextcloud/Dockerfile
+++ b/tfgrid3/nextcloud/Dockerfile
@@ -31,7 +31,7 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Zinit
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit && \
   chmod +x /sbin/zinit
 
 COPY ./Caddyfile /etc/caddy/

--- a/tfgrid3/nomad/client/Dockerfile
+++ b/tfgrid3/nomad/client/Dockerfile
@@ -23,7 +23,7 @@ RUN apt update
 
 RUN apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.12/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.12/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit

--- a/tfgrid3/nomad/server/Dockerfile
+++ b/tfgrid3/nomad/server/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && \
 RUN wget https://releases.hashicorp.com/nomad/1.6.2/nomad_1.6.2_linux_amd64.zip && unzip nomad_1.6.2_linux_amd64.zip && \
     mv nomad /usr/bin && rm nomad_1.6.2_linux_amd64.zip
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.12/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.12/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit

--- a/tfgrid3/nostr_relay-mycelium/Dockerfile
+++ b/tfgrid3/nostr_relay-mycelium/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && \
     apt install -y wget curl git build-essential gcc make librust-openssl-dev protobuf-compiler libprotobuf-dev openssh-server ufw
 
 # Download and install latest zinit
-RUN curl -s https://api.github.com/repos/threefoldtech/zos_zinit/releases/latest | \
+RUN curl -s https://api.github.com/repos/threefoldtech/zinit/releases/latest | \
     grep "browser_download_url" | \
     cut -d '"' -f 4 | \
     wget -qi - -O /sbin/zinit

--- a/tfgrid3/owncloud/Dockerfile
+++ b/tfgrid3/owncloud/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-RUN wget https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit -O /sbin/zinit \
+RUN wget https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit -O /sbin/zinit \
     && chmod +x /sbin/zinit
     
 COPY ./scripts/ /scripts/

--- a/tfgrid3/peertube/Dockerfile
+++ b/tfgrid3/peertube/Dockerfile
@@ -33,7 +33,7 @@ VOLUME /data /config
 EXPOSE 9000 1935
 
 RUN apt -y install wget vim net-tools && \
-    wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+    wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit

--- a/tfgrid3/presearch/Dockerfile
+++ b/tfgrid3/presearch/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
     apt -y install wget curl vim net-tools iputils-ping openssh-server docker.io
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit

--- a/tfgrid3/staticwebsite/Dockerfile
+++ b/tfgrid3/staticwebsite/Dockerfile
@@ -12,7 +12,7 @@ RUN  apt install -y debian-keyring debian-archive-keyring apt-transport-https cu
     apt install caddy 
 RUN    apt install -y git
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit

--- a/tfgrid3/subsquid/Dockerfile
+++ b/tfgrid3/subsquid/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-c
 RUN curl -sL https://deb.nodesource.com/setup_16.x -o /tmp/nodesource_setup.sh && \
     bash /tmp/nodesource_setup.sh
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit

--- a/tfgrid3/tfrobot/Dockerfile
+++ b/tfgrid3/tfrobot/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get install -y wget software-properties-common curl openssh-server ufw
 
 # Download and install latest zinit
-RUN curl -s https://api.github.com/repos/threefoldtech/zos_zinit/releases/latest | \
+RUN curl -s https://api.github.com/repos/threefoldtech/zinit/releases/latest | \
     grep "browser_download_url" | \
     cut -d '"' -f 4 | \
     wget -qi - -O /sbin/zinit

--- a/tfgrid3/ubuntu22.04/microvm/Dockerfile
+++ b/tfgrid3/ubuntu22.04/microvm/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 RUN apt update && \
   apt -y install wget openssh-server
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.5/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit && \
   chmod +x /sbin/zinit
 
 COPY zinit /etc/zinit

--- a/tfgrid3/ubuntu23.10/Dockerfile
+++ b/tfgrid3/ubuntu23.10/Dockerfile
@@ -9,7 +9,7 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ub
     apt install -y wget curl git openssh-server ufw
 
 # Download and install latest zinit
-RUN curl -s https://api.github.com/repos/threefoldtech/zos_zinit/releases/latest | \
+RUN curl -s https://api.github.com/repos/threefoldtech/zinit/releases/latest | \
     grep "browser_download_url" | \
     cut -d '"' -f 4 | \
     wget -qi - -O /sbin/zinit

--- a/tfgrid3/ubuntu24.04/microvm/Dockerfile
+++ b/tfgrid3/ubuntu24.04/microvm/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 RUN apt update && \
   apt -y install wget openssh-server
 
-RUN wget -O /sbin/zinit https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.14/zinit && \
+RUN wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.14/zinit && \
   chmod +x /sbin/zinit
 
 COPY zinit /etc/zinit

--- a/tfgrid3/umbrel/README.md
+++ b/tfgrid3/umbrel/README.md
@@ -9,7 +9,7 @@ This image based on Debian.
 - Docker
 - Docker-compose
 - include preinstalled openssh-client, yq, openssh-server, curl, iproute2, python3 and some other packages.
-- [zinit](https://github.com/threefoldtech/zos_zinit) process manager which is configured with these services:
+- [zinit](https://github.com/threefoldtech/zinit) process manager which is configured with these services:
 
   - **sshd**: starting OpenSSH server daemon
   - **ssh_config**: Add the user SSH key to authorized_keys, so he can log in remotely to the host which running this image.

--- a/tfgrid3/umbrel/dockerfile
+++ b/tfgrid3/umbrel/dockerfile
@@ -16,7 +16,7 @@ RUN /bin/bash -c  "/scripts/yq.sh;"
 
 
 
-RUN curl --location  https://github.com/threefoldtech/zos_zinit/releases/download/v0.2.10/zinit -o /sbin/zinit && \
+RUN curl --location  https://github.com/threefoldtech/zinit/releases/download/v0.2.10/zinit -o /sbin/zinit && \
     chmod +x /sbin/zinit
 
 RUN mkdir -p /etc/zinit;

--- a/tfgrid3/wordpress/Dockerfile
+++ b/tfgrid3/wordpress/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
-	wget https://github.com/threefoldtech/zos_zinit/releases/download/0.2.14/zinit -O /sbin/zinit; \
+	wget https://github.com/threefoldtech/zinit/releases/download/0.2.14/zinit -O /sbin/zinit; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
 	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \


### PR DESCRIPTION
The zinit and rfs repos were renamed back to their original names. Revert threefoldtech/zos_zinit -> threefoldtech/zinit and threefoldtech/zos_rfs -> threefoldtech/rfs. Other renames (zos_config / zos_sdk_go / zos_initramfs) are left intact.